### PR TITLE
Add RUBYGEM_MIRROR env var to Ruby 2.2+ images for custom mirror

### DIFF
--- a/2.2/README.md
+++ b/2.2/README.md
@@ -112,6 +112,10 @@ file inside your source code repository.
 
     This variable indicate the number of worker processes that will be launched. See documentation on Puma's [clustered mode](https://github.com/puma/puma#clustered-mode).
 
+* **RUBYGEM_MIRROR**
+
+    Set this variable to use a custom RubyGems mirror URL to download required gem packages during build process.
+
 Hot deploy
 ---------------------
 In order to dynamically pick up changes made in your application source code, you need to make following steps:

--- a/2.2/s2i/bin/assemble
+++ b/2.2/s2i/bin/assemble
@@ -16,6 +16,10 @@ set -e
 
 export RACK_ENV=${RACK_ENV:-"production"}
 
+if [ -n "$RUBYGEM_MIRROR" ]; then
+  bundle config mirror.https://rubygems.org $RUBYGEM_MIRROR
+fi
+
 echo "---> Installing application source ..."
 cp -Rf /tmp/src/. ./
 

--- a/2.3/README.md
+++ b/2.3/README.md
@@ -112,6 +112,10 @@ file inside your source code repository.
 
     This variable indicate the number of worker processes that will be launched. See documentation on Puma's [clustered mode](https://github.com/puma/puma#clustered-mode).
 
+* **RUBYGEM_MIRROR**
+
+    Set this variable to use a custom RubyGems mirror URL to download required gem packages during build process.
+
 Hot deploy
 ---------------------
 In order to dynamically pick up changes made in your application source code, you need to make following steps:

--- a/2.3/s2i/bin/assemble
+++ b/2.3/s2i/bin/assemble
@@ -16,6 +16,10 @@ set -e
 
 export RACK_ENV=${RACK_ENV:-"production"}
 
+if [ -n "$RUBYGEM_MIRROR" ]; then
+  bundle config mirror.https://rubygems.org $RUBYGEM_MIRROR
+fi
+
 echo "---> Installing application source ..."
 cp -Rf /tmp/src/. ./
 


### PR DESCRIPTION
The new RUBYGEM_MIRROR env var is introduced to allow users to add
custom rubygems mirror.

The env var is only available Ruby 2.2+ images only. As a result,
Ruby 2.0 image doesn't support this env var.

Signed-off-by: Vu Dinh <vdinh@redhat.com>