### PR TITLE
Use current git URL in README.md and usage files.

### DIFF
--- a/2.0/README.md
+++ b/2.0/README.md
@@ -10,19 +10,19 @@ The resulting image can be run using [Docker](http://docker.io).
 
 Usage
 ---------------------
-To build a simple [ruby-sample-app](https://github.com/openshift/s2i-ruby/tree/master/2.0/test/puma-test-app) application
+To build a simple [ruby-sample-app](https://github.com/sclorg/s2i-ruby-container/tree/master/2.0/test/puma-test-app) application
 using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
 resulting image with [Docker](http://docker.io) execute:
 
 *  **For RHEL based image**
     ```
-    $ s2i build https://github.com/openshift/s2i-ruby.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-rhel7 ruby-sample-app
+    $ s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-rhel7 ruby-sample-app
     $ docker run -p 8080:8080 ruby-sample-app
     ```
 
 *  **For CentOS based image**
     ```
-    $ s2i build https://github.com/openshift/s2i-ruby.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-centos7 ruby-sample-app
+    $ s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-centos7 ruby-sample-app
     $ docker run -p 8080:8080 ruby-sample-app
     ```
 

--- a/2.0/s2i/bin/usage
+++ b/2.0/s2i/bin/usage
@@ -8,7 +8,7 @@ To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-s2i build https://github.com/openshift/s2i-ruby.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-${DISTRO}7 ruby-sample-app
+s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-${DISTRO}7 ruby-sample-app
 
 
 You can then run the resulting image via:

--- a/2.2/README.md
+++ b/2.2/README.md
@@ -10,19 +10,19 @@ The resulting image can be run using [Docker](http://docker.io).
 
 Usage
 ---------------------
-To build a simple [ruby-sample-app](https://github.com/openshift/s2i-ruby/tree/master/2.2/test/puma-test-app) application
+To build a simple [ruby-sample-app](https://github.com/sclorg/s2i-ruby-container/tree/master/2.2/test/puma-test-app) application
 using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
 resulting image with [Docker](http://docker.io) execute:
 
 *  **For RHEL based image**
     ```
-    $ s2i build https://github.com/openshift/s2i-ruby.git --context-dir=2.2/test/puma-test-app/ rhscl/ruby-22-rhel7 ruby-sample-app
+    $ s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.2/test/puma-test-app/ rhscl/ruby-22-rhel7 ruby-sample-app
     $ docker run -p 8080:8080 ruby-sample-app
     ```
 
 *  **For CentOS based image**
     ```
-    $ s2i build https://github.com/openshift/s2i-ruby.git --context-dir=2.2/test/puma-test-app/ centos/ruby-22-centos7 ruby-sample-app
+    $ s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.2/test/puma-test-app/ centos/ruby-22-centos7 ruby-sample-app
     $ docker run -p 8080:8080 ruby-sample-app
     ```
 

--- a/2.2/s2i/bin/usage
+++ b/2.2/s2i/bin/usage
@@ -10,7 +10,7 @@ To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-s2i build https://github.com/openshift/s2i-ruby.git --context-dir=2.2/test/puma-test-app/ ${NAMESPACE}/ruby-22-${DISTRO}7 ruby-sample-app
+s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.2/test/puma-test-app/ ${NAMESPACE}/ruby-22-${DISTRO}7 ruby-sample-app
 
 
 You can then run the resulting image via:

--- a/2.3/README.md
+++ b/2.3/README.md
@@ -10,19 +10,19 @@ The resulting image can be run using [Docker](http://docker.io).
 
 Usage
 ---------------------
-To build a simple [ruby-sample-app](https://github.com/openshift/sti-ruby/tree/master/2.3/test/puma-test-app) application
+To build a simple [ruby-sample-app](https://github.com/sclorg/s2i-ruby-container/tree/master/2.3/test/puma-test-app) application
 using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
 resulting image with [Docker](http://docker.io) execute:
 
 *  **For RHEL based image**
     ```
-    $ s2i build https://github.com/openshift/sti-ruby.git --context-dir=2.3/test/puma-test-app/ rhscl/ruby-23-rhel7 ruby-sample-app
+    $ s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.3/test/puma-test-app/ rhscl/ruby-23-rhel7 ruby-sample-app
     $ docker run -p 8080:8080 ruby-sample-app
     ```
 
 *  **For CentOS based image**
     ```
-    $ s2i build https://github.com/openshift/sti-ruby.git --context-dir=2.3/test/puma-test-app/ centos/ruby-23-centos7 ruby-sample-app
+    $ s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.3/test/puma-test-app/ centos/ruby-23-centos7 ruby-sample-app
     $ docker run -p 8080:8080 ruby-sample-app
     ```
 

--- a/2.3/s2i/bin/usage
+++ b/2.3/s2i/bin/usage
@@ -10,7 +10,7 @@ To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-s2i build https://github.com/openshift/sti-ruby.git --context-dir=2.3/test/puma-test-app/ ${NAMESPACE}/ruby-23-${DISTRO}7 ruby-sample-app
+s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.3/test/puma-test-app/ ${NAMESPACE}/ruby-23-${DISTRO}7 ruby-sample-app
 
 
 You can then run the resulting image via:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
     subscribed RHEL machine.
 
     ```
-    $ git clone https://github.com/openshift/s2i-ruby.git
+    $ git clone https://github.com/sclorg/s2i-ruby-container.git
     $ cd s2i-ruby
     $ make build TARGET=rhel7 VERSION=2.0
     ```
@@ -54,7 +54,7 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
     To build a Ruby image from scratch run:
 
     ```
-    $ git clone https://github.com/openshift/s2i-ruby.git
+    $ git clone https://github.com/sclorg/s2i-ruby-container.git
     $ cd s2i-ruby
     $ make build VERSION=2.0
     ```


### PR DESCRIPTION
Obsolete openshift git repo was referenced.