### PR TITLE
Fix using subscription in container

### DIFF
--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -20,7 +20,10 @@ LABEL BZComponent="openshift-sti-ruby-docker" \
       Release="2" \
       Architecture="x86_64"
 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="ruby200 ruby200-ruby-devel ruby200-rubygem-rake v8314 ror40-rubygem-bundler nodejs010" && \
     yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && rpm -V $INSTALL_PKGS && \

--- a/2.2/Dockerfile.rhel7
+++ b/2.2/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM openshift/base-rhel7
+FROM rhscl/s2i-base-rhel7
 
 # This image provides a Ruby 2.2 environment you can use to run your Ruby
 # applications.
@@ -20,7 +20,10 @@ LABEL BZComponent="rh-ruby22-docker" \
       Release="1" \
       Architecture="x86_64"
 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="rh-ruby22 rh-ruby22-ruby-devel rh-ruby22-rubygem-rake v8314 rh-ruby22-rubygem-bundler nodejs010" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && rpm -V $INSTALL_PKGS && \

--- a/2.3/Dockerfile.rhel7
+++ b/2.3/Dockerfile.rhel7
@@ -20,7 +20,10 @@ LABEL BZComponent="rh-ruby23-docker" \
       Release="4.1" \
       Architecture="x86_64"
 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake rh-ruby23-rubygem-bundler rh-nodejs4" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
Enabling host repositories didn't work with docker 1.10 and newer inside OpenStack. It was fixed in latest rhel7 base release, so using 'rhel7' base image is required for RHEL CI. Postgresql PR - sclorg/postgresql-container#150

Also to enable repositories inside container running 'yum' first is required - see https://access.redhat.com/solutions/1443553 . Similar to sclorg/s2i-base-container#99 .

Also `rhscl/s2i-base-rhel7` have should be used for `rhscl/` namespaced images. I've added it to this PR, because it is also required to have `Dockerfile.rhel7` working.

@hhorak @bparees Please take a look and merge.