### PR TITLE
Fix test for RHSCL 2.3

### DIFF
--- a/2.3/test/run
+++ b/2.3/test/run
@@ -181,7 +181,7 @@ for server in ${WEB_SERVERS[@]}; do
   test_connection
   check_result $?
 
-  test_scl_usage "ruby --version" "ruby 2.3.0"
+  test_scl_usage "ruby --version" "ruby 2.3."
   check_result $?
 
   info "All tests for the ${server}-test-app finished successfully."


### PR DESCRIPTION
In RHSCL 2.3 ruby is updated to 2.3.1p112. Test expects 2.3.0 so it is failing.

@hhorak Please take a look. Also required by sclorg/s2i-base-container#106.