### PR TITLE
Ensure we use BUNDLE_WITHOUT

### DIFF
--- a/2.2/s2i/bin/assemble
+++ b/2.2/s2i/bin/assemble
@@ -39,6 +39,10 @@ if [ -f Gemfile ]; then
     BUNDLE_WITHOUT=${BUNDLE_WITHOUT:-"development:test"}
   fi
 
+  if [ -n "$BUNDLE_WITHOUT" ]; then
+    ADDTL_BUNDLE_ARGS+=" --without $BUNDLE_WITHOUT"
+  fi
+
   echo "---> Running 'bundle install ${ADDTL_BUNDLE_ARGS}' ..."
   bundle install --path ./bundle ${ADDTL_BUNDLE_ARGS}
 

--- a/2.3/s2i/bin/assemble
+++ b/2.3/s2i/bin/assemble
@@ -38,7 +38,11 @@ if [ -f Gemfile ]; then
   else
     BUNDLE_WITHOUT=${BUNDLE_WITHOUT:-"development:test"}
   fi
-
+  
+  if [ -n "$BUNDLE_WITHOUT" ]; then
+    ADDTL_BUNDLE_ARGS+=" --without $BUNDLE_WITHOUT"
+  fi
+  
   echo "---> Running 'bundle install ${ADDTL_BUNDLE_ARGS}' ..."
   bundle install --path ./bundle ${ADDTL_BUNDLE_ARGS}
 


### PR DESCRIPTION
At the moment the BUNDLE_WITHOUT is being populated however the result of this was not actually being passed to the bundle install arguments. This looks to test if the BUNDLE_WITHOUT env variable is set and if it is pass it with the without flag to the bundle install command.