### PR TITLE
Use centos/ namespaced s2i base image

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/base-centos7
+FROM centos/s2i-base-centos7
 
 # This image provides a Ruby 2.2 environment you can use to run your Ruby
 # applications.

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/base-centos7
+FROM centos/s2i-base-centos7
 
 # This image provides a Ruby 2.3 environment you can use to run your Ruby
 # applications.


### PR DESCRIPTION
For centos/ namespaced images use centos/ namespaced s2i base image. This image is based on https://github.com/sclorg/s2i-base-container/ and is built by coreservices-jenkins maintained by RHSCL team.

@hhorak @bparees Please take a look and merge.