### PR TITLE
Update Dockerfiles

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -3,16 +3,28 @@ FROM centos/s2i-base-centos7
 # This image provides a Ruby 2.2 environment you can use to run your Ruby
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV RUBY_VERSION 2.2
 
-LABEL io.k8s.description="Platform for building and running Ruby 2.2 applications" \
+ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as docker container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Ruby 2.2" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,ruby,ruby22"
+      io.openshift.tags="builder,ruby,ruby22" \
+      com.redhat.component="rh-ruby22-docker" \
+      name="centos/ruby-22-centos7" \
+      version="2.2" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 RUN INSTALL_PKGS="rh-ruby22 rh-ruby22-ruby-devel rh-ruby22-rubygem-rake v8314 rh-ruby22-rubygem-bundler nodejs010" && \
     yum install -y centos-release-scl && \

--- a/2.2/Dockerfile.rhel7
+++ b/2.2/Dockerfile.rhel7
@@ -7,18 +7,23 @@ EXPOSE 8080
 
 ENV RUBY_VERSION 2.2
 
-LABEL summary="Platform for building and running Ruby 2.2 applications" \
-      io.k8s.description="Platform for building and running Ruby 2.2 applications" \
+ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as docker container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Ruby 2.2" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,ruby,ruby22"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-ruby22-docker" \
+      io.openshift.tags="builder,ruby,ruby22" \
+      com.redhat.component="rh-ruby22-docker" \
       name="rhscl/ruby-22-rhel7" \
       version="2.2" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -3,17 +3,28 @@ FROM centos/s2i-base-centos7
 # This image provides a Ruby 2.3 environment you can use to run your Ruby
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV RUBY_VERSION 2.3
 
-LABEL summary="Platform for building and running Ruby 2.3 applications" \
-      io.k8s.description="Platform for building and running Ruby 2.3 applications" \
+ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as docker container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Ruby 2.3" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,ruby,ruby23,rh-ruby23"
+      io.openshift.tags="builder,ruby,ruby23,rh-ruby23" \
+      com.redhat.component="rh-ruby23-docker" \
+      name="centos/ruby-23-centos7" \
+      version="2.3" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 RUN yum install -y centos-release-scl && \
     yum-config-manager --enable centos-sclo-rh-testing && \

--- a/2.3/Dockerfile.rhel7
+++ b/2.3/Dockerfile.rhel7
@@ -7,18 +7,23 @@ EXPOSE 8080
 
 ENV RUBY_VERSION 2.3
 
-LABEL summary="Platform for building and running Ruby 2.3 applications" \
-      io.k8s.description="Platform for building and running Ruby 2.3 applications" \
+ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as docker container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Ruby 2.3" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,ruby,ruby23,rh-ruby23"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-ruby23-docker" \
+      io.openshift.tags="builder,ruby,ruby23,rh-ruby23" \
+      com.redhat.component="rh-ruby23-docker" \
       name="rhscl/ruby-23-rhel7" \
       version="2.3" \
-      release="4.1" \
-      architecture="x86_64"
+      release="4.1"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -7,11 +7,24 @@ EXPOSE 8080
 
 ENV RUBY_VERSION 2.4
 
-LABEL summary="Platform for building and running Ruby 2.4 applications" \
-      io.k8s.description="Platform for building and running Ruby 2.4 applications" \
+ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as docker container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Ruby 2.4" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,ruby,ruby24,rh-ruby24"
+      io.openshift.tags="builder,ruby,ruby24,rh-ruby24" \
+      com.redhat.component="rh-ruby24-docker" \
+      name="centos/ruby-24-centos7" \
+      version="2.4" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -7,18 +7,23 @@ EXPOSE 8080
 
 ENV RUBY_VERSION 2.4
 
-LABEL summary="Platform for building and running Ruby 2.4 applications" \
-      io.k8s.description="Platform for building and running Ruby 2.4 applications" \
+ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as docker container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Ruby 2.4" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,ruby,ruby24,rh-ruby24"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-ruby24-docker" \
+      io.openshift.tags="builder,ruby,ruby24,rh-ruby24" \
+      com.redhat.component="rh-ruby24-docker" \
       name="rhscl/ruby-24-rhel7" \
       version="2.4" \
-      release="2.1" \
-      architecture="x86_64"
+      release="2.1"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553


### PR DESCRIPTION
Provide same labels for all base image variants (CentOS, RHEL, Fedora)
 - follow recomended labels from Project Atomic Container best practices
 - add summary and description labels (Fedora requirements) - use ENV for simple using of same value in more descriptive labels
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)
 - use label 'maintainer' (MAINTAINER instruction is deprecated)
                                           
(don't use separate instruction for each label)

@hhorak @praiskup @pkubatrh Please take a look and merge.