### PR TITLE
Simplify default calculation of number of puma workers

### DIFF
--- a/2.0/root/opt/app-root/etc/puma.cfg
+++ b/2.0/root/opt/app-root/etc/puma.cfg
@@ -9,6 +9,15 @@ def get_max_memory()
     (2 ** (8*0.size - 2) - 1)
 end
 
+def get_memory_per_worker()
+    bytes = ENV.fetch('MEMORY_BYTES_PER_WORKER', '0').to_i
+    if bytes == 0
+        # Comment describing rationale for choosing default of 256MiB/worker is below.
+        bytes = 256 * (2**20)
+    end
+    bytes
+end
+
 def get_min_threads()
     ENV.fetch('PUMA_MIN_THREADS', '0').to_i
 end
@@ -18,18 +27,19 @@ def get_max_threads()
 end
 
 # Determine the maximum number of workers that are allowed by the available
-# memory. Puma documentation recommends the maximum number of workers to be
-# set to the number cores.
+# memory.  Puma documentation recommends the maximum number of workers to be
+# set to the number of cores.
+# Unless we're specifically tuned otherwise, allow one worker process per 256MiB
+# memory, to a maximum of 1 worker / core.  Hopefully that'll be a reasonable
+# starting point for average apps; if not, it's all tunable.  The simple
+# OpenShift ruby/rails sample app currently requires approx. 60MiB +
+# 70MiB/worker before taking its first request, so hopefully a default of
+# 256MiB/worker will give other simple apps reasonable default headroom.
 def get_workers()
     return ENV['PUMA_WORKERS'].to_i if ENV.has_key? 'PUMA_WORKERS'
 
-    base_memory = 50 * 1024 * 1024
-    per_worker_base_memory = 15 * 1024 * 1024
-    per_thread_memory = 128 * 1024
-
     cores = ENV.fetch('NUMBER_OF_CORES', '1').to_i
-    per_worker_memory = per_worker_base_memory + per_thread_memory*get_max_threads()
-    max_workers = (get_max_memory() - base_memory) / per_worker_memory
+    max_workers = get_max_memory() / get_memory_per_worker()
 
     [cores, max_workers].min
 end

--- a/2.2/root/opt/app-root/etc/puma.cfg
+++ b/2.2/root/opt/app-root/etc/puma.cfg
@@ -9,6 +9,15 @@ def get_max_memory()
     (2 ** (8*0.size - 2) - 1)
 end
 
+def get_memory_per_worker()
+    bytes = ENV.fetch('MEMORY_BYTES_PER_WORKER', '0').to_i
+    if bytes == 0
+        # Comment describing rationale for choosing default of 256MiB/worker is below.
+        bytes = 256 * (2**20)
+    end
+    bytes
+end
+
 def get_min_threads()
     ENV.fetch('PUMA_MIN_THREADS', '0').to_i
 end
@@ -18,18 +27,19 @@ def get_max_threads()
 end
 
 # Determine the maximum number of workers that are allowed by the available
-# memory. Puma documentation recommends the maximum number of workers to be
-# set to the number cores.
+# memory.  Puma documentation recommends the maximum number of workers to be
+# set to the number of cores.
+# Unless we're specifically tuned otherwise, allow one worker process per 256MiB
+# memory, to a maximum of 1 worker / core.  Hopefully that'll be a reasonable
+# starting point for average apps; if not, it's all tunable.  The simple
+# OpenShift ruby/rails sample app currently requires approx. 60MiB +
+# 70MiB/worker before taking its first request, so hopefully a default of
+# 256MiB/worker will give other simple apps reasonable default headroom.
 def get_workers()
     return ENV['PUMA_WORKERS'].to_i if ENV.has_key? 'PUMA_WORKERS'
 
-    base_memory = 50 * 1024 * 1024
-    per_worker_base_memory = 15 * 1024 * 1024
-    per_thread_memory = 128 * 1024
-
     cores = ENV.fetch('NUMBER_OF_CORES', '1').to_i
-    per_worker_memory = per_worker_base_memory + per_thread_memory*get_max_threads()
-    max_workers = (get_max_memory() - base_memory) / per_worker_memory
+    max_workers = get_max_memory() / get_memory_per_worker()
 
     [cores, max_workers].min
 end

--- a/2.3/root/opt/app-root/etc/puma.cfg
+++ b/2.3/root/opt/app-root/etc/puma.cfg
@@ -9,6 +9,15 @@ def get_max_memory()
     (2 ** (8*0.size - 2) - 1)
 end
 
+def get_memory_per_worker()
+    bytes = ENV.fetch('MEMORY_BYTES_PER_WORKER', '0').to_i
+    if bytes == 0
+        # Comment describing rationale for choosing default of 256MiB/worker is below.
+        bytes = 256 * (2**20)
+    end
+    bytes
+end
+
 def get_min_threads()
     ENV.fetch('PUMA_MIN_THREADS', '0').to_i
 end
@@ -18,18 +27,19 @@ def get_max_threads()
 end
 
 # Determine the maximum number of workers that are allowed by the available
-# memory. Puma documentation recommends the maximum number of workers to be
-# set to the number cores.
+# memory.  Puma documentation recommends the maximum number of workers to be
+# set to the number of cores.
+# Unless we're specifically tuned otherwise, allow one worker process per 256MiB
+# memory, to a maximum of 1 worker / core.  Hopefully that'll be a reasonable
+# starting point for average apps; if not, it's all tunable.  The simple
+# OpenShift ruby/rails sample app currently requires approx. 60MiB +
+# 70MiB/worker before taking its first request, so hopefully a default of
+# 256MiB/worker will give other simple apps reasonable default headroom.
 def get_workers()
     return ENV['PUMA_WORKERS'].to_i if ENV.has_key? 'PUMA_WORKERS'
 
-    base_memory = 50 * 1024 * 1024
-    per_worker_base_memory = 15 * 1024 * 1024
-    per_thread_memory = 128 * 1024
-
     cores = ENV.fetch('NUMBER_OF_CORES', '1').to_i
-    per_worker_memory = per_worker_base_memory + per_thread_memory*get_max_threads()
-    max_workers = (get_max_memory() - base_memory) / per_worker_memory
+    max_workers = get_max_memory() / get_memory_per_worker()
 
     [cores, max_workers].min
 end

--- a/2.4/root/opt/app-root/etc/puma.cfg
+++ b/2.4/root/opt/app-root/etc/puma.cfg
@@ -9,6 +9,15 @@ def get_max_memory()
     (2 ** (8*0.size - 2) - 1)
 end
 
+def get_memory_per_worker()
+    bytes = ENV.fetch('MEMORY_BYTES_PER_WORKER', '0').to_i
+    if bytes == 0
+        # Comment describing rationale for choosing default of 256MiB/worker is below.
+        bytes = 256 * (2**20)
+    end
+    bytes
+end
+
 def get_min_threads()
     ENV.fetch('PUMA_MIN_THREADS', '0').to_i
 end
@@ -18,18 +27,19 @@ def get_max_threads()
 end
 
 # Determine the maximum number of workers that are allowed by the available
-# memory. Puma documentation recommends the maximum number of workers to be
-# set to the number cores.
+# memory.  Puma documentation recommends the maximum number of workers to be
+# set to the number of cores.
+# Unless we're specifically tuned otherwise, allow one worker process per 256MiB
+# memory, to a maximum of 1 worker / core.  Hopefully that'll be a reasonable
+# starting point for average apps; if not, it's all tunable.  The simple
+# OpenShift ruby/rails sample app currently requires approx. 60MiB +
+# 70MiB/worker before taking its first request, so hopefully a default of
+# 256MiB/worker will give other simple apps reasonable default headroom.
 def get_workers()
     return ENV['PUMA_WORKERS'].to_i if ENV.has_key? 'PUMA_WORKERS'
 
-    base_memory = 50 * 1024 * 1024
-    per_worker_base_memory = 15 * 1024 * 1024
-    per_thread_memory = 128 * 1024
-
     cores = ENV.fetch('NUMBER_OF_CORES', '1').to_i
-    per_worker_memory = per_worker_base_memory + per_thread_memory*get_max_threads()
-    max_workers = (get_max_memory() - base_memory) / per_worker_memory
+    max_workers = get_max_memory() / get_memory_per_worker()
 
     [cores, max_workers].min
 end


### PR DESCRIPTION
If not already tuned by the caller, allow (configurable) 256MiB per worker and cap the number of
workers at the number of cores.

fixes #141