### PR TITLE
only check for rake not rails when compiling assets

### DIFF
--- a/2.0/s2i/bin/assemble
+++ b/2.0/s2i/bin/assemble
@@ -4,8 +4,7 @@ function rake_assets_precompile() {
   [[ "$DISABLE_ASSET_COMPILATION" == "true" ]] && return
   [ ! -f Gemfile ] && return
   [ ! -f Rakefile ] && return
-  ! grep " rails " Gemfile.lock >/dev/null && return
-  ! grep " execjs " Gemfile.lock >/dev/null && return
+  ! grep " rake " Gemfile.lock >/dev/null && return
   ! bundle exec 'rake -T' | grep "assets:precompile" >/dev/null && return
 
   echo "---> Starting asset compilation ..."

--- a/2.2/s2i/bin/assemble
+++ b/2.2/s2i/bin/assemble
@@ -4,8 +4,7 @@ function rake_assets_precompile() {
   [[ "$DISABLE_ASSET_COMPILATION" == "true" ]] && return
   [ ! -f Gemfile ] && return
   [ ! -f Rakefile ] && return
-  ! grep " rails " Gemfile.lock >/dev/null && return
-  ! grep " execjs " Gemfile.lock >/dev/null && return
+  ! grep " rake " Gemfile.lock >/dev/null && return
   ! bundle exec 'rake -T' | grep "assets:precompile" >/dev/null && return
 
   echo "---> Starting asset compilation ..."

--- a/2.3/s2i/bin/assemble
+++ b/2.3/s2i/bin/assemble
@@ -4,8 +4,7 @@ function rake_assets_precompile() {
   [[ "$DISABLE_ASSET_COMPILATION" == "true" ]] && return
   [ ! -f Gemfile ] && return
   [ ! -f Rakefile ] && return
-  ! grep " rails " Gemfile.lock >/dev/null && return
-  ! grep " execjs " Gemfile.lock >/dev/null && return
+  ! grep " rake " Gemfile.lock >/dev/null && return
   ! bundle exec 'rake -T' | grep "assets:precompile" >/dev/null && return
 
   echo "---> Starting asset compilation ..."

--- a/2.4/s2i/bin/assemble
+++ b/2.4/s2i/bin/assemble
@@ -4,8 +4,7 @@ function rake_assets_precompile() {
   [[ "$DISABLE_ASSET_COMPILATION" == "true" ]] && return
   [ ! -f Gemfile ] && return
   [ ! -f Rakefile ] && return
-  ! grep " rails " Gemfile.lock >/dev/null && return
-  ! grep " execjs " Gemfile.lock >/dev/null && return
+  ! grep " rake " Gemfile.lock >/dev/null && return
   ! bundle exec 'rake -T' | grep "assets:precompile" >/dev/null && return
 
   echo "---> Starting asset compilation ..."


### PR DESCRIPTION
it is perfectly fine to have an `assets:precompile` rake target on
non-rails setups (like sinatra). this change allows such setups to run
`rake assets:precompile` when needed, by only checking the presence of
`rake` in the Gemfile, so that `rake -T` can be executed.