### PR TITLE
Update scL-enable to use node6

### DIFF
--- a/2.3/root/opt/app-root/etc/scl_enable
+++ b/2.3/root/opt/app-root/etc/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-ruby23 rh-nodejs4
+source scl_source enable rh-ruby23 rh-nodejs6


### PR DESCRIPTION
rhscl-node6 is already in the appliance, this changes the environment to use it
Nodejs is needed to use webpacker with webpack, the default javascript server for Rails 5.1 and up. it has some capabilities needed to integrate with Vue, React and Angular.