### PR TITLE
Update Go version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 language: go
 
-go: 1.6
+go: latest
 
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
source-to-image [cannot be build](https://travis-ci.org/sclorg/s2i-ruby-container/builds/302946195#L521) with Go 1.6 after [the latest update of Godeps](https://github.com/openshift/source-to-image/commit/c2be0ab3991d90d87f9f0e6f318e7cf03276c0d1). Travis file has to be updated.