### PR TITLE
Add --retry arg for 'bundle install'

### DIFF
--- a/2.2/s2i/bin/assemble
+++ b/2.2/s2i/bin/assemble
@@ -25,9 +25,9 @@ mv /tmp/src/* ./
 
 echo "---> Building your Ruby application from source ..."
 if [ -f Gemfile ]; then
-  ADDTL_BUNDLE_ARGS=""
+  ADDTL_BUNDLE_ARGS="--retry 2"
   if [ -f Gemfile.lock ]; then
-    ADDTL_BUNDLE_ARGS="--deployment"
+    ADDTL_BUNDLE_ARGS+=" --deployment"
   fi
 
   if [[ "$RAILS_ENV" == "development" || "$RACK_ENV" == "development" ]]; then

--- a/2.3/s2i/bin/assemble
+++ b/2.3/s2i/bin/assemble
@@ -25,9 +25,9 @@ mv /tmp/src/* ./
 
 echo "---> Building your Ruby application from source ..."
 if [ -f Gemfile ]; then
-  ADDTL_BUNDLE_ARGS=""
+  ADDTL_BUNDLE_ARGS="--retry 2"
   if [ -f Gemfile.lock ]; then
-    ADDTL_BUNDLE_ARGS="--deployment"
+    ADDTL_BUNDLE_ARGS+=" --deployment"
   fi
 
   if [[ "$RAILS_ENV" == "development" || "$RACK_ENV" == "development" ]]; then

--- a/2.4/s2i/bin/assemble
+++ b/2.4/s2i/bin/assemble
@@ -25,9 +25,9 @@ mv /tmp/src/* ./
 
 echo "---> Building your Ruby application from source ..."
 if [ -f Gemfile ]; then
-  ADDTL_BUNDLE_ARGS=""
+  ADDTL_BUNDLE_ARGS="--retry 2"
   if [ -f Gemfile.lock ]; then
-    ADDTL_BUNDLE_ARGS="--deployment"
+    ADDTL_BUNDLE_ARGS+=" --deployment"
   fi
 
   if [[ "$RAILS_ENV" == "development" || "$RACK_ENV" == "development" ]]; then


### PR DESCRIPTION
Retry connection in case it breaks. 
https://github.com/sclorg/s2i-ruby-container/issues/122  
 
I've set it to 2 retries, which is not much overhead, in case someone 
dislikes the feature. 
Bundler in SCL with Ruby 2.2 and later support retries (Ruby 2.0 does not).