### PR TITLE
Add fedora variant

### DIFF
--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -1,0 +1,85 @@
+FROM registry.fedoraproject.org/f27/s2i-base:latest
+
+# This image provides a Ruby 2.4 environment you can use to run your Ruby
+# applications.
+
+EXPOSE 8080
+
+ENV NAME=ruby \
+    RUBY_VERSION=2.4 \
+    VERSION=0 \
+    RELEASE=1 \
+    ARCH=x86_64
+
+ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as docker container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      name="$FGC/$NAME" \
+      com.redhat.component="$NAME" \
+      release="RELEASE.$DISTTAG" \
+      architecture="$ARCH" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Ruby 2.4" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,ruby,ruby24,rh-ruby24" \
+      usage="s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.4/test/puma-test-app/ registry.fedoraproject.org/$FGC/ruby ruby-sample-app" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# Install required packages
+RUN INSTALL_PKGS="bsdtar \
+    bzip2 \
+    cmake \
+    community-mysql-devel \
+    findutils \
+    gcc-c++ \
+    gd-devel \
+    gdb \
+    gettext \
+    git \
+    libcurl-devel \
+    libxml2-devel \
+    libxslt-devel \
+    lsof \
+    make \
+    nodejs \
+    npm \
+    openssl-devel \
+    patch \
+    postgresql-devel \
+    procps-ng \
+    python \
+    redhat-rpm-config \
+    ruby \
+    ruby-devel \
+    rubygem-bundler \
+    rubygem-rake \
+    rubygems-devel \
+    sqlite-devel \
+    tar \
+    unzip \
+    wget \
+    which" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    dnf clean all
+
+# S2I scripts
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
+    rpm-file-permissions
+
+USER 1001
+
+# Command which will start service during command `docker run`
+CMD $STI_SCRIPTS_PATH/usage

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -38,21 +38,6 @@ run_s2i_build() {
   s2i build ${s2i_args} file://${test_dir}/${1}-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 }
 
-prepare() {
-  if ! image_exists ${IMAGE_NAME}; then
-    echo "ERROR: The image ${IMAGE_NAME} must exist before this script is executed."
-    exit 1
-  fi
-  # TODO: S2I build require the application is a valid 'GIT' repository, we
-  # should remove this restriction in the future when a file:// is used.
-  info "Build the test application image"
-  pushd ${test_dir}/${1}-test-app >/dev/null
-  git init
-  git config user.email "build@localhost" && git config user.name "builder"
-  git add -A && git commit -m "Sample commit"
-  popd >/dev/null
-}
-
 run_test_application() {
   docker run --user=100001 --rm --cidfile=${cid_file} ${IMAGE_NAME}-testapp
 }
@@ -160,7 +145,6 @@ for server in ${WEB_SERVERS[@]}; do
   # it from Docker hub
   s2i_args="--pull-policy=never"
 
-  prepare ${server}
   run_s2i_build ${server}
   check_result $?
 


### PR DESCRIPTION
The tests are failing for me locally. Seems like there is something wrong with mysql2 (db-test-app). I even had to s/mariadb/community-mysql/.

```
/opt/app-root/src/bundle/ruby/2.4.0/gems/mysql2-0.3.16/lib/mysql2/client.rb:12:in `<class:Client>': uninitialized constant Mysql2::Client::SECURE_CONNECTION (NameError)
```

The other commit in this PR is addressing this issue (git changed its behavior maybe?):

```
+ s2i build --pull-policy=never
file:///home/tt/g/s2i-ruby-container/2.4/test/db-test-app f27/ruby
f27/ruby-testapp
Checking if image "f27/ruby" is available locally ...
Checking if image "f27/ruby" is available locally ...
Your branch is up to date with 'origin/master'.
fatal: No url found for submodule path 'ruby-hello-world' in .gitmodules
Build failed
ERROR: An error occurred: exit status 128
```
  