### PR TITLE
Add Ruby 2.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,7 @@ install:
   - hack/build-go.sh
   - popd
 
-script: SKIP_SQUASH=1 make test TARGET=centos7
+script:
+  # Unset an environment variable that causes failure in test.
+  - unset RUBY_VERSION
+  - SKIP_SQUASH=1 make test TARGET=centos7

--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -1,0 +1,62 @@
+FROM centos/s2i-base-centos7
+
+# This image provides a Ruby environment you can use to run your Ruby
+# applications.
+
+EXPOSE 8080
+
+ENV RUBY_MAJOR_VERSION=2 \
+    RUBY_MINOR_VERSION=5
+
+ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
+    RUBY_SCL_NAME_VERSION="${RUBY_MAJOR_VERSION}${RUBY_MINOR_VERSION}"
+
+ENV RUBY_SCL="rh-ruby${RUBY_SCL_NAME_VERSION}" \
+    IMAGE_NAME="centos/ruby-${RUBY_SCL_NAME_VERSION}-centos7" \
+    SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Ruby ${RUBY_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,ruby,ruby${RUBY_SCL_NAME_VERSION},${RUBY_SCL}" \
+      com.redhat.component="${RUBY_SCL}-docker" \
+      name="${IMAGE_NAME}" \
+      version="${RUBY_VERSION}" \
+      usage="s2i build https://github.com/sclorg/s2i-ruby-container.git \
+--context-dir=${RUBY_VERSION}/test/puma-test-app/ ${IMAGE_NAME} ruby-sample-app" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+RUN yum install -y centos-release-scl-rh && \
+    yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-ruby25-rh-candidate/x86_64/os/ && \
+    echo gpgcheck=0 >> /etc/yum.repos.d/cbs.centos.org_repos_sclo7-rh-ruby25-rh-candidate_x86_64_os_.repo && \
+    INSTALL_PKGS=" \
+${RUBY_SCL} \
+${RUBY_SCL}-ruby-devel \
+${RUBY_SCL}-rubygem-rake \
+${RUBY_SCL}-rubygem-bundler \
+" && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    yum clean all -y && \
+    rpm -V ${INSTALL_PKGS}
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
+    rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/2.5/Dockerfile.rhel7
+++ b/2.5/Dockerfile.rhel7
@@ -1,0 +1,61 @@
+FROM rhscl/s2i-base-rhel7:1
+
+# This image provides a Ruby environment you can use to run your Ruby
+# applications.
+
+EXPOSE 8080
+
+ENV RUBY_MAJOR_VERSION=2 \
+    RUBY_MINOR_VERSION=5
+
+ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
+    RUBY_SCL_NAME_VERSION="${RUBY_MAJOR_VERSION}${RUBY_MINOR_VERSION}"
+
+ENV RUBY_SCL="rh-ruby${RUBY_SCL_NAME_VERSION}" \
+    IMAGE_NAME="rhscl/ruby-${RUBY_SCL_NAME_VERSION}-rhel7" \
+    SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Ruby ${RUBY_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,ruby,ruby${RUBY_SCL_NAME_VERSION},${RUBY_SCL}" \
+      com.redhat.component="${RUBY_SCL}-docker" \
+      name="${IMAGE_NAME}" \
+      version="${RUBY_VERSION}" \
+      usage="s2i build https://github.com/sclorg/s2i-ruby-container.git \
+--context-dir=${RUBY_VERSION}/test/puma-test-app/ ${IMAGE_NAME} ruby-sample-app" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+RUN yum install -y yum-utils && \
+    prepare-yum-repositories rhel-server-rhscl-7-rpms rhel-server-rhscl-7-beta-rpms && \
+    INSTALL_PKGS=" \
+${RUBY_SCL} \
+${RUBY_SCL}-ruby-devel \
+${RUBY_SCL}-rubygem-rake \
+${RUBY_SCL}-rubygem-bundler \
+" && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    yum clean all -y && \
+    rpm -V ${INSTALL_PKGS}
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
+    rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/2.5/README.md
+++ b/2.5/README.md
@@ -1,0 +1,141 @@
+Ruby 2.5 container image
+=================
+
+This container image includes Ruby 2.5 as a [S2I](https://github.com/openshift/source-to-image) base image for your Ruby 2.5 applications.
+Users can choose between RHEL and CentOS based builder images.
+The RHEL image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/ruby-25-rhel7)
+as registry.access.redhat.com/rhscl/ruby-25-rhel7.
+The CentOS image is then available on [Docker Hub](https://hub.docker.com/r/centos/ruby-25-centos7/)
+as centos/ruby-25-centos7.
+The resulting image can be run using [Docker](http://docker.io).
+
+Description
+-----------
+
+Ruby 2.5 available as container is a base platform for
+building and running various Ruby 2.5 applications and frameworks.
+Ruby is the interpreted scripting language for quick and easy object-oriented programming.
+It has many features to process text files and to do system management tasks (as in Perl).
+It is simple, straight-forward, and extensible.
+
+Usage
+---------------------
+To build a simple [ruby-sample-app](https://github.com/sclorg/s2i-ruby-container/tree/master/2.5/test/puma-test-app) application
+using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
+resulting image with [Docker](http://docker.io) execute:
+
+*  **For RHEL based image**
+    ```
+    $ s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.5/test/puma-test-app/ rhscl/ruby-25-rhel7 ruby-sample-app
+    $ docker run -p 8080:8080 ruby-sample-app
+    ```
+
+*  **For CentOS based image**
+    ```
+    $ s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.5/test/puma-test-app/ centos/ruby-25-centos7 ruby-sample-app
+    $ docker run -p 8080:8080 ruby-sample-app
+    ```
+
+**Accessing the application:**
+```
+$ curl 127.0.0.1:8080
+```
+
+Environment variables
+---------------------
+
+To set these environment variables, you can place them as a key value pair into a `.sti/environment`
+file inside your source code repository.
+
+* **RACK_ENV**
+
+    This variable specifies the environment where the Ruby application will be deployed (unless overwritten) - `production`, `development`, `test`.
+    Each level has different behaviors in terms of logging verbosity, error pages, ruby gem installation, etc.
+
+    **Note**: Application assets will be compiled only if the `RACK_ENV` is set to `production`
+
+* **DISABLE_ASSET_COMPILATION**
+
+    This variable set to `true` indicates that the asset compilation process will be skipped. Since this only takes place
+    when the application is run in the `production` environment, it should only be used when assets are already compiled.
+
+* **PUMA_MIN_THREADS**, **PUMA_MAX_THREADS**
+
+    These variables indicate the minimum and maximum threads that will be available in [Puma](https://github.com/puma/puma)'s thread pool.
+
+* **PUMA_WORKERS**
+
+    This variable indicate the number of worker processes that will be launched. See documentation on Puma's [clustered mode](https://github.com/puma/puma#clustered-mode).
+
+* **RUBYGEM_MIRROR**
+
+    Set this variable to use a custom RubyGems mirror URL to download required gem packages during build process.
+
+Hot deploy
+---------------------
+In order to dynamically pick up changes made in your application source code, you need to make following steps:
+
+*  **For Ruby on Rails applications**
+
+    Run the built Rails image with the `RAILS_ENV=development` environment variable passed to the [Docker](http://docker.io) `-e` run flag:
+    ```
+    $ docker run -e RAILS_ENV=development -p 8080:8080 rails-app
+    ```
+*  **For other types of Ruby applications (Sinatra, Padrino, etc.)**
+
+    Your application needs to be built with one of gems that reloads the server every time changes in source code are done inside the running container. Those gems are:
+    * [Shotgun](https://github.com/rtomayko/shotgun)
+    * [Rerun](https://github.com/alexch/rerun)
+    * [Rack-livereload](https://github.com/johnbintz/rack-livereload)
+
+    Please note that in order to be able to run your application in development mode, you need to modify the [S2I run script](https://github.com/openshift/source-to-image#anatomy-of-a-builder-image), so the web server is launched by the chosen gem, which checks for changes in the source code.
+
+    After you built your application image with your version of [S2I run script](https://github.com/openshift/source-to-image#anatomy-of-a-builder-image), run the image with the RACK_ENV=development environment variable passed to the [Docker](http://docker.io) -e run flag:
+    ```
+    $ docker run -e RACK_ENV=development -p 8080:8080 sinatra-app
+    ```
+
+To change your source code in running container, use Docker's [exec](http://docker.io) command:
+```
+docker exec -it <CONTAINER_ID> /bin/bash
+```
+
+After you [Docker exec](http://docker.io) into the running container, your current
+directory is set to `/opt/app-root/src`, where the source code is located.
+
+Performance tuning
+---------------------
+You can tune the number of threads per worker using the
+`PUMA_MIN_THREADS` and `PUMA_MAX_THREADS` environment variables.
+Additionally, the number of worker processes is determined by the number of CPU
+cores that the container has available, as recommended by
+[Puma](https://github.com/puma/puma)'s documentation. This is determined using
+the cgroup [cpusets](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt)
+subsystem. You can specify the cores that the container is allowed to use by passing
+the `--cpuset-cpus` parameter to the [Docker](http://docker.io) run command:
+```
+$ docker run -e PUMA_MAX_THREADS=32 --cpuset-cpus='0-2,3,5' -p 8080:8080 sinatra-app
+```
+The number of workers is also limited by the memory limit that is enforced using
+cgroups. The builder image assumes that you will need 50 MiB as a base and
+another 15 MiB for every worker process plus 128 KiB for each thread. Note that
+each worker has its own threads, so the total memory required for the whole
+container is computed using the following formula:
+
+```
+50 + 15 * WORKERS + 0.125 * WORKERS * PUMA_MAX_THREADS
+```
+You can specify a memory limit using the `--memory` flag:
+```
+$ docker run -e PUMA_MAX_THREADS=32 --memory=300m -p 8080:8080 sinatra-app
+```
+If memory is more limiting then the number of available cores, the number of
+workers is scaled down accordingly to fit the above formula. The number of
+workers can also be set explicitly by setting `PUMA_WORKERS`.
+
+
+See also
+--------
+Dockerfile and other sources are available on https://github.com/sclorg/s2i-ruby-container.
+In that repository you also can find another versions of Python environment Dockerfiles.
+Dockerfile for CentOS is called Dockerfile, Dockerfile for RHEL is called Dockerfile.rhel7.

--- a/2.5/cccp.yml
+++ b/2.5/cccp.yml
@@ -1,0 +1,3 @@
+# This is for the purpose of building this container
+# on the centos container pipeline.
+job-id: ruby-25-centos7

--- a/2.5/root/opt/app-root/.gemrc
+++ b/2.5/root/opt/app-root/.gemrc
@@ -1,0 +1,9 @@
+---
+install: --no-document
+update: --no-document
+:benchmark: false
+:update_sources: true
+:bulk_threshold: 1000
+:backtrace: true
+:sources:
+- https://rubygems.org/

--- a/2.5/root/opt/app-root/etc/puma.cfg
+++ b/2.5/root/opt/app-root/etc/puma.cfg
@@ -1,0 +1,50 @@
+def get_max_memory()
+    return ENV['MEMORY_LIMIT_IN_BYTES'].to_i if ENV.has_key? 'MEMORY_LIMIT_IN_BYTES'
+
+    # Assume unlimited memory. 0.size is the number of bytes a Ruby
+    # Fixnum class can hold. One bit is used for sign and one is used
+    # by Ruby to determine whether it's a number or pointer to an object.
+    # That's why we subtract two bits. This expresion should therefore be
+    # the largest signed Fixnum possible.
+    (2 ** (8*0.size - 2) - 1)
+end
+
+def get_memory_per_worker()
+    bytes = ENV.fetch('MEMORY_BYTES_PER_WORKER', '0').to_i
+    if bytes == 0
+        # Comment describing rationale for choosing default of 256MiB/worker is below.
+        bytes = 256 * (2**20)
+    end
+    bytes
+end
+
+def get_min_threads()
+    ENV.fetch('PUMA_MIN_THREADS', '0').to_i
+end
+
+def get_max_threads()
+    ENV.fetch('PUMA_MAX_THREADS', '16').to_i
+end
+
+# Determine the maximum number of workers that are allowed by the available
+# memory.  Puma documentation recommends the maximum number of workers to be
+# set to the number of cores.
+# Unless we're specifically tuned otherwise, allow one worker process per 256MiB
+# memory, to a maximum of 1 worker / core.  Hopefully that'll be a reasonable
+# starting point for average apps; if not, it's all tunable.  The simple
+# OpenShift ruby/rails sample app currently requires approx. 60MiB +
+# 70MiB/worker before taking its first request, so hopefully a default of
+# 256MiB/worker will give other simple apps reasonable default headroom.
+def get_workers()
+    return ENV['PUMA_WORKERS'].to_i if ENV.has_key? 'PUMA_WORKERS'
+
+    cores = ENV.fetch('NUMBER_OF_CORES', '1').to_i
+    max_workers = get_max_memory() / get_memory_per_worker()
+
+    [cores, max_workers].min
+end
+
+environment ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'production'
+threads     get_min_threads(), get_max_threads()
+workers     get_workers()
+bind        'tcp://0.0.0.0:8080'

--- a/2.5/root/opt/app-root/etc/scl_enable
+++ b/2.5/root/opt/app-root/etc/scl_enable
@@ -1,0 +1,6 @@
+# IMPORTANT: Do not add more content to this file unless you know what you are
+#            doing. This file is sourced everytime the shell session is opened.
+#
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-ruby25 rh-nodejs6

--- a/2.5/s2i/bin/assemble
+++ b/2.5/s2i/bin/assemble
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+function rake_assets_precompile() {
+  [[ "$DISABLE_ASSET_COMPILATION" == "true" ]] && return
+  [ ! -f Gemfile ] && return
+  [ ! -f Rakefile ] && return
+  ! grep " rake " Gemfile.lock >/dev/null && return
+  ! bundle exec 'rake -T' | grep "assets:precompile" >/dev/null && return
+
+  echo "---> Starting asset compilation ..."
+  bundle exec rake assets:precompile
+}
+
+set -e
+
+export RACK_ENV=${RACK_ENV:-"production"}
+
+if [ -n "$RUBYGEM_MIRROR" ]; then
+  bundle config mirror.https://rubygems.org $RUBYGEM_MIRROR
+fi
+
+shopt -s dotglob
+echo "---> Installing application source ..."
+mv /tmp/src/* ./
+
+echo "---> Building your Ruby application from source ..."
+if [ -f Gemfile ]; then
+  ADDTL_BUNDLE_ARGS="--retry 2"
+  if [ -f Gemfile.lock ]; then
+    ADDTL_BUNDLE_ARGS+=" --deployment"
+  fi
+
+  if [[ "$RAILS_ENV" == "development" || "$RACK_ENV" == "development" ]]; then
+    BUNDLE_WITHOUT=${BUNDLE_WITHOUT:-"test"}
+  elif [[ "$RAILS_ENV" == "test" || "$RACK_ENV" == "test" ]]; then
+    BUNDLE_WITHOUT=${BUNDLE_WITHOUT:-"development"}
+  else
+    BUNDLE_WITHOUT=${BUNDLE_WITHOUT:-"development:test"}
+  fi
+  
+  if [ -n "$BUNDLE_WITHOUT" ]; then
+    ADDTL_BUNDLE_ARGS+=" --without $BUNDLE_WITHOUT"
+  fi
+  
+  echo "---> Running 'bundle install ${ADDTL_BUNDLE_ARGS}' ..."
+  bundle install --path ./bundle ${ADDTL_BUNDLE_ARGS}
+
+  echo "---> Cleaning up unused ruby gems ..."
+  bundle clean -V
+fi
+
+if ! bundle exec rackup -h &>/dev/null; then
+  echo "WARNING: Rubygem Rack is not installed in the present image."
+  echo "         Add rack to your Gemfile in order to start the web server."
+fi
+
+if [[ "$RAILS_ENV" == "production" || "$RACK_ENV" == "production" ]]; then
+  rake_assets_precompile
+fi
+
+# Fix source directory permissions
+fix-permissions ./
+
+# Make the ./tmp folder world writeable as Rails or other frameworks might use
+# it to store temporary data (uploads/cache/sessions/etcd).
+# The ./db folder has to be writeable as well because when Rails complete the
+# migration it writes the schema version into ./db/schema.db
+set +e
+[[ -d ./tmp ]] && chgrp -R 0 ./tmp && chmod -R g+rw ./tmp
+[[ -d ./db ]] && chgrp -R 0 ./db && chmod -R g+rw ./db
+set -e

--- a/2.5/s2i/bin/run
+++ b/2.5/s2i/bin/run
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+function is_puma_installed() {
+  [ ! -f Gemfile.lock ] && return 1
+  grep ' puma ' Gemfile.lock >/dev/null
+}
+
+set -e
+
+function check_number() {
+  if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+    echo "$1 needs to be a non-negative number"
+    exit 1
+  fi
+}
+check_number PUMA_WORKERS     "${PUMA_WORKERS:-0}"
+check_number PUMA_MIN_THREADS "${PUMA_MIN_THREADS:-0}"
+check_number PUMA_MAX_THREADS "${PUMA_MAX_THREADS:-0}"
+
+export RACK_ENV=${RACK_ENV:-"production"}
+
+if is_puma_installed; then
+  export_vars=$(cgroup-limits) ; export $export_vars
+
+  exec bundle exec "puma --config ../etc/puma.cfg"
+else
+  echo "You might consider adding 'puma' into your Gemfile."
+
+  if bundle exec rackup -h &>/dev/null; then
+    if [ -f Gemfile ]; then
+      exec bundle exec "rackup -E ${RAILS_ENV:-$RACK_ENV} -P /tmp/rack.pid --host 0.0.0.0 --port 8080"
+    else
+      exec rackup -E "${RAILS_ENV:-$RACK_ENV}" -P /tmp/rack.pid --host 0.0.0.0 --port 8080
+    fi
+  else
+    echo "ERROR: Rubygem Rack is not installed in the present image."
+    echo "       Add rack to your Gemfile in order to start the web server."
+  fi
+fi

--- a/2.5/s2i/bin/usage
+++ b/2.5/s2i/bin/usage
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+NAMESPACE=centos
+[[ $DISTRO =~ rhel* ]] && NAMESPACE=rhscl
+
+cat <<EOF
+This is a S2I ruby-${RUBY_VERSION} ${DISTRO} base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=${RUBY_VERSION}/test/puma-test-app/ ${NAMESPACE}/ruby-${RUBY_SCL_NAME_VERSION}-${DISTRO}7 ruby-sample-app
+
+
+You can then run the resulting image via:
+docker run -p 8080:8080 ruby-sample-app
+EOF

--- a/2.5/test/puma-test-app/Gemfile
+++ b/2.5/test/puma-test-app/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'
+gem 'puma'

--- a/2.5/test/puma-test-app/Gemfile.lock
+++ b/2.5/test/puma-test-app/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mustermann (1.0.1)
+    puma (3.11.2)
+    rack (2.0.4)
+    rack-protection (2.0.0)
+      rack
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
+    tilt (2.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  puma
+  sinatra

--- a/2.5/test/puma-test-app/app.rb
+++ b/2.5/test/puma-test-app/app.rb
@@ -1,0 +1,5 @@
+require 'sinatra'
+
+get '/' do
+  'Hello world!'
+end

--- a/2.5/test/puma-test-app/config.ru
+++ b/2.5/test/puma-test-app/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/2.5/test/rack-test-app/Gemfile
+++ b/2.5/test/rack-test-app/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'

--- a/2.5/test/rack-test-app/Gemfile.lock
+++ b/2.5/test/rack-test-app/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mustermann (1.0.1)
+    rack (2.0.4)
+    rack-protection (2.0.0)
+      rack
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
+    tilt (2.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sinatra

--- a/2.5/test/rack-test-app/app.rb
+++ b/2.5/test/rack-test-app/app.rb
@@ -1,0 +1,5 @@
+require 'sinatra'
+
+get '/' do
+  'Hello world!'
+end

--- a/2.5/test/rack-test-app/config.ru
+++ b/2.5/test/rack-test-app/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/2.5/test/run
+++ b/2.5/test/run
@@ -1,0 +1,180 @@
+#!/bin/bash -x
+#
+# The 'run' performs a simple test that verifies that S2I image.
+# The main focus here is to excersise the S2I scripts.
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+IMAGE_NAME=${IMAGE_NAME-centos/ruby-25-centos7-candidate}
+
+declare -a WEB_SERVERS=(db puma rack)
+#declare -a WEB_SERVERS=(db)
+
+# TODO: Make command compatible for Mac users
+test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
+image_dir=$(readlink -zf ${test_dir}/..)
+
+# Read exposed port from image meta data
+test_port="$(docker inspect --format='{{range $key, $value := .Config.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"
+
+info() {
+  echo -e "\n\e[1m[INFO] $@...\e[0m\n"
+}
+
+image_exists() {
+  docker inspect $1 &>/dev/null
+}
+
+container_exists() {
+  image_exists $(cat $cid_file)
+}
+
+container_ip() {
+  docker inspect --format="{{ .NetworkSettings.IPAddress }}" $(cat $cid_file)
+}
+
+run_s2i_build() {
+  s2i build ${s2i_args} file://${test_dir}/${1}-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+}
+
+run_test_application() {
+  docker run --user=100001 --rm --cidfile=${cid_file} ${IMAGE_NAME}-testapp
+}
+
+cleanup() {
+  local server="$1"
+  info "Cleaning up the test application image $1"
+  if [ -f $cid_file ]; then
+    if container_exists; then
+      docker stop $(cat $cid_file)
+    fi
+  fi
+  if image_exists ${IMAGE_NAME}-testapp; then
+    docker rmi -f ${IMAGE_NAME}-testapp
+  fi
+  if [ ! -z "${server}" ]; then
+    rm -rf ${test_dir}/${server}-test-app/.git
+  fi
+  if [[ "${server}" == "db" ]]; then
+    rm -rf ${test_dir}/db-test-app
+  fi
+}
+
+check_result() {
+  local result="$1"
+  if [[ "$result" != "0" ]]; then
+    info "TEST FAILED (${result})"
+    cleanup
+    exit $result
+  fi
+}
+
+wait_for_cid() {
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  info "Waiting for application container to start"
+  while [ $attempt -le $max_attempts ]; do
+    [ -f $cid_file ] && [ -s $cid_file ] && break
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+}
+
+test_s2i_usage() {
+  info "Testing 's2i usage'"
+  s2i usage ${s2i_args} ${IMAGE_NAME} &>/dev/null
+}
+
+test_docker_run_usage() {
+  info "Testing 'docker run' usage"
+  docker run ${IMAGE_NAME} &>/dev/null
+}
+
+test_connection() {
+  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  while [ $attempt -le $max_attempts ]; do
+    response_code=$(curl -s -w %{http_code} -o /dev/null http://$(container_ip):${test_port}/)
+    status=$?
+    if [ $status -eq 0 ]; then
+      if [ $response_code -eq 200 ]; then
+        result=0
+      fi
+      break
+    fi
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+  return $result
+}
+
+test_scl_usage() {
+  local run_cmd="$1"
+  local expected="$2"
+
+  info "Testing the image SCL enable"
+  out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}")
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  out=$(docker exec $(cat ${cid_file}) /bin/bash -c "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  out=$(docker exec $(cat ${cid_file}) /bin/sh -ic "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+}
+
+pushd ${test_dir}
+if [ -d db-test-app ]; then
+  rm -rf db-test-app
+fi
+git clone git://github.com/openshift/ruby-hello-world db-test-app
+popd
+
+for server in ${WEB_SERVERS[@]}; do
+  cid_file=$(mktemp -u --suffix=.cid)
+
+  # Since we built the candidate image locally, we don't want S2I attempt to pull
+  # it from Docker hub
+  s2i_args="--pull-policy=never"
+
+  run_s2i_build ${server}
+  check_result $?
+
+  # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
+  test_s2i_usage
+  check_result $?
+
+  # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
+  test_docker_run_usage
+  check_result $?
+
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_connection
+  check_result $?
+
+  test_scl_usage "ruby --version" "ruby ${RUBY_VERSION}."
+  check_result $?
+
+  info "All tests for the ${server}-test-app finished successfully."
+  cleanup ${server}
+done
+
+info "All tests finished successfully."

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in common/build.sh.
 BASE_IMAGE_NAME = ruby
-VERSIONS = 2.2 2.3 2.4
+VERSIONS = 2.2 2.3 2.4 2.5
 OPENSHIFT_NAMESPACES = 2.0
 
 # HACK:  Ensure that 'git pull' for old clones doesn't cause confusion.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Ruby versions currently provided are:
 * [Ruby 2.2](2.2/README.md)
 * [Ruby 2.3](2.3/README.md)
 * [Ruby 2.4](2.4/README.md)
+* [Ruby 2.5](2.5/README.md)
 
 RHEL versions currently supported are:
 * RHEL7
@@ -48,7 +49,7 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
     ```
     $ git clone --recursive https://github.com/sclorg/s2i-ruby-container.git
     $ cd s2i-ruby-container
-    $ make build TARGET=rhel7 VERSIONS=2.4
+    $ make build TARGET=rhel7 VERSIONS=2.5
     ```
 
 *  **CentOS based image**
@@ -64,7 +65,7 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
     ```
     $ git clone --recursive https://github.com/sclorg/s2i-ruby-container.git
     $ cd s2i-ruby-container
-    $ make build TARGET=centos7 VERSIONS=2.4
+    $ make build TARGET=centos7 VERSIONS=2.5
     ```
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed
@@ -84,6 +85,9 @@ see [usage documentation](2.3/README.md).
 For information about usage of Dockerfile for Ruby 2.4,
 see [usage documentation](2.4/README.md).
 
+For information about usage of Dockerfile for Ruby 2.5,
+see [usage documentation](2.5/README.md).
+
 
 Test
 ---------------------
@@ -99,14 +103,14 @@ Users can choose between testing a Ruby test application based on a RHEL or Cent
 
     ```
     $ cd s2i-ruby-container
-    $ make test TARGET=rhel7 VERSIONS=2.4
+    $ make test TARGET=rhel7 VERSIONS=2.5
     ```
 
 *  **CentOS based image**
 
     ```
     $ cd s2i-ruby-container
-    $ make test TARGET=centos7 VERSIONS=2.4
+    $ make test TARGET=centos7 VERSIONS=2.5
     ```
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed

--- a/imagestreams/ruby-centos7.json
+++ b/imagestreams/ruby-centos7.json
@@ -107,6 +107,23 @@
         "referencePolicy": {
           "type": "Local"
         }
+      },
+      {
+        "name": "2.5",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 2.5",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 2.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "supports": "ruby:2.5,ruby",
+          "version": "2.5",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "docker.io/centos/ruby-25-centos7:latest"
+        }
       }
     ]
   }

--- a/imagestreams/ruby-rhel7.json
+++ b/imagestreams/ruby-rhel7.json
@@ -107,6 +107,23 @@
         "referencePolicy": {
           "type": "Local"
         }
+      },
+      {
+        "name": "2.5",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 2.5",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 2.5 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "supports": "ruby:2.5,ruby",
+          "version": "2.5",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/rhscl/ruby-25-rhel7:latest"
+        }
       }
     ]
   }


### PR DESCRIPTION
This PR is only for RHEL-7. It does not include the logic for CentOS.
This time I added environment variables in `Dockerfile` to reduce editing Ruby version text manually when updating the version.

I tested like this.

```
$ make build TARGET=rhel7 VERSIONS=2.5

$ docker images

$ docker run 1f4087f0a79f
This is a S2I ruby-2.5 rhel base image:
To use it, install S2I: https://github.com/openshift/source-to-image

Sample invocation:

s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.5/test/puma-test-app/ rhscl/ruby-25-rhel7 ruby-sample-app


You can then run the resulting image via:
docker run -p 8080:8080 ruby-sample-app

$ docker run -it 1f4087f0a79f bash
```

```
$ make test TARGET=rhel7 VERSIONS=2.5
...
[INFO] All tests finished successfully....
```

Thanks for reviewing this.
