### PR TITLE
Remove `community-mysql-devel` from INSTALL_PKGS

### DIFF
--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -35,7 +35,6 @@ LABEL summary="$SUMMARY" \
 RUN INSTALL_PKGS="bsdtar \
     bzip2 \
     cmake \
-    community-mysql-devel \
     findutils \
     gcc-c++ \
     gd-devel \


### PR DESCRIPTION
as ti conflicts with preinstalled package `mariadb-devel`.

https://ci.centos.org/job/SCLo-container-ruby-rh-fedora/3/console