### PR TITLE
adding imagestream definition for ruby 2.5 on ppc64le

### DIFF
--- a/imagestreams/ruby-rhel7-ppc64le.json
+++ b/imagestreams/ruby-rhel7-ppc64le.json
@@ -1,0 +1,54 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "ruby_ppc64le",
+    "annotations": {
+      "openshift.io/display-name": "Ruby (ppc64le)"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Ruby (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.5/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major versions updates.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "supports": "ruby",
+          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "2.5"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "2.5",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 2.5 (ppc64le)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 2.5 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
+          "iconClass": "icon-ruby",
+          "importer.image.openshift.io/prefer-arch": "ppc64le",
+          "tags": "builder,ruby",
+          "supports": "ruby_ppc64le:2.5,ruby_ppc64le",
+          "version": "2.5",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/rhscl/ruby-25-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adding this ruby image stream that will support ppc64le. It is worth noting that ruby 2.5 in the ruby-rhel7.json  imagestream definition will work on ppc64le because it is manifest listed on the registry. I've added "importer.image.openshift.io/prefer-arch": "ppc64le" to this definition to guarantee that only the ppc64le container will be pulled (for better or worse).
