### PR TITLE
Change imagestream name from 'ruby_ppc64le' to 'ruby'.

### DIFF
--- a/imagestreams/ruby-rhel7-ppc64le.json
+++ b/imagestreams/ruby-rhel7-ppc64le.json
@@ -2,9 +2,9 @@
   "kind": "ImageStream",
   "apiVersion": "v1",
   "metadata": {
-    "name": "ruby_ppc64le",
+    "name": "ruby",
     "annotations": {
-      "openshift.io/display-name": "Ruby (ppc64le)"
+      "openshift.io/display-name": "Ruby"
     }
   },
   "spec": {
@@ -14,9 +14,9 @@
         "annotations": {
           "openshift.io/display-name": "Ruby (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.5/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major versions updates.",
+          "description": "Build and run Ruby applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major versions updates.",
           "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
+          "tags": "builder,ruby,ppc64le",
           "supports": "ruby",
           "sampleRepo": "https://github.com/openshift/ruby-ex.git"
         },
@@ -31,13 +31,12 @@
       {
         "name": "2.5",
         "annotations": {
-          "openshift.io/display-name": "Ruby 2.5 (ppc64le)",
+          "openshift.io/display-name": "Ruby 2.5",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "description": "Build and run Ruby 2.5 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
           "iconClass": "icon-ruby",
-          "importer.image.openshift.io/prefer-arch": "ppc64le",
-          "tags": "builder,ruby",
-          "supports": "ruby_ppc64le:2.5,ruby_ppc64le",
+          "tags": "builder,ruby,ppc64le",
+          "supports": "ruby:2.5,ruby",
           "version": "2.5",
           "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },


### PR DESCRIPTION
Cleaning up ppc64le ruby imagestream name to match 3.10 & 3.11 definition.