### PR TITLE
OKD rebranding and sclorg move for s2i-ruby-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Users can choose between RHEL and CentOS based builder images.
 The resulting image can be run using [Docker](http://docker.io).
 
 For more information about using these images with OpenShift, please see the
-official [OpenShift Documentation](https://docs.openshift.org/latest/using_images/s2i_images/ruby.html).
+official [OpenShift Documentation](https://docs.okd.io/latest/using_images/s2i_images/ruby.html).
 
 Versions
 ---------------

--- a/examples/rails-postgresql-persistent.json
+++ b/examples/rails-postgresql-persistent.json
@@ -5,16 +5,16 @@
     "name": "rails-pgsql-persistent",
     "annotations": {
       "openshift.io/display-name": "Rails + PostgreSQL (Persistent)",
-      "description": "An example Rails application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/openshift/rails-ex/blob/master/README.md.",
+      "description": "An example Rails application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
       "tags": "quickstart,ruby,rails",
       "iconClass": "icon-ruby",
       "template.openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.",
       "template.openshift.io/provider-display-name": "Red Hat, Inc.",
-      "template.openshift.io/documentation-url": "https://github.com/openshift/rails-ex",
+      "template.openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
       "template.openshift.io/support-url": "https://access.redhat.com"
     }
   },
-  "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/openshift/rails-ex/blob/master/README.md.",
+  "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
   "labels": {
     "template": "rails-pgsql-persistent"
   },
@@ -515,7 +515,7 @@
       "displayName": "Git Repository URL",
       "required": true,
       "description": "The URL of the repository with your application source code.",
-      "value": "https://github.com/openshift/rails-ex.git"
+      "value": "https://github.com/sclorg/rails-ex.git"
     },
     {
       "name": "SOURCE_REPOSITORY_REF",

--- a/examples/rails-postgresql.json
+++ b/examples/rails-postgresql.json
@@ -5,16 +5,16 @@
     "name": "rails-postgresql-example",
     "annotations": {
       "openshift.io/display-name": "Rails + PostgreSQL (Ephemeral)",
-      "description": "An example Rails application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/openshift/rails-ex/blob/master/README.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.",
+      "description": "An example Rails application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.",
       "tags": "quickstart,ruby,rails",
       "iconClass": "icon-ruby",
       "template.openshift.io/long-description": "This template defines resources needed to develop a Rails application, including a build configuration, application deployment configuration, and database deployment configuration.  The database is stored in non-persistent storage, so this configuration should be used for experimental purposes only.",
       "template.openshift.io/provider-display-name": "Red Hat, Inc.",
-      "template.openshift.io/documentation-url": "https://github.com/openshift/rails-ex",
+      "template.openshift.io/documentation-url": "https://github.com/sclorg/rails-ex",
       "template.openshift.io/support-url": "https://access.redhat.com"
     }
   },
-  "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/openshift/rails-ex/blob/master/README.md.",
+  "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/rails-ex/blob/master/README.md.",
   "labels": {
     "template": "rails-postgresql-example"
   },
@@ -489,7 +489,7 @@
       "displayName": "Git Repository URL",
       "required": true,
       "description": "The URL of the repository with your application source code.",
-      "value": "https://github.com/openshift/rails-ex.git"
+      "value": "https://github.com/sclorg/rails-ex.git"
     },
     {
       "name": "SOURCE_REPOSITORY_REF",

--- a/imagestreams/ruby-centos7.json
+++ b/imagestreams/ruby-centos7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
           "supports": "ruby",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,builder,ruby",
           "supports": "ruby:2.0,ruby",
           "version": "2.0",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,ruby",
           "supports": "ruby:2.2,ruby",
           "version": "2.2",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,ruby",
           "supports": "ruby:2.3,ruby",
           "version": "2.3",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -98,7 +98,7 @@
           "tags": "builder,ruby",
           "supports": "ruby:2.4,ruby",
           "version": "2.4",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/imagestreams/ruby-rhel7-ppc64le.json
+++ b/imagestreams/ruby-rhel7-ppc64le.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-ruby",
           "tags": "builder,ruby,ppc64le",
           "supports": "ruby",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",

--- a/imagestreams/ruby-rhel7.json
+++ b/imagestreams/ruby-rhel7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
           "supports": "ruby",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,builder,ruby",
           "supports": "ruby:2.0,ruby",
           "version": "2.0",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,ruby",
           "supports": "ruby:2.2,ruby",
           "version": "2.2",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,ruby",
           "supports": "ruby:2.3,ruby",
           "version": "2.3",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -98,7 +98,7 @@
           "tags": "builder,ruby",
           "supports": "ruby:2.4,ruby",
           "version": "2.4",
-          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
         },
         "from": {
           "kind": "DockerImage",


### PR DESCRIPTION
docs.openshift.org to docs.okd.io
github.com/openshift/rails-ex to github.com/sclorg/rails-ex
github.com/openshift/ruby-ex to github.com/sclorg/ruby-ex