### PR TITLE
.travis.yml: Specify golang version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 language: go
 
-go: latest
+go: stable
 
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
Hi @pkubatrh . This PR fixes the Travis CI test failure.

Related to https://github.com/sclorg/s2i-ruby-container/pull/199

It seems `go: latest` does not work. But it looked worked before (?), seeing the past Travis CI on the master branch. At least `go` 1.7.4 was used.

https://travis-ci.org/sclorg/s2i-ruby-container/builds/467536796

Seeing below document and a popular go application, I changed the go version to `1.7.x`.
https://docs.travis-ci.com/user/languages/go/
https://github.com/stretchr/testify/blob/master/.travis.yml

And this works on my forked repository.
https://travis-ci.org/junaruga/s2i-ruby-container/builds/491654733