### PR TITLE
Regenerate `Gemfile.lock` in test apps

### DIFF
--- a/2.2/test/puma-test-app/Gemfile.lock
+++ b/2.2/test/puma-test-app/Gemfile.lock
@@ -1,16 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    puma (2.8.2)
-      rack (>= 1.1, < 2.0)
-    rack (1.5.2)
-    rack-protection (1.5.0)
+    mustermann (1.0.3)
+    puma (3.12.1)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    sinatra (1.4.5)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    tilt (1.4.1)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby

--- a/2.2/test/rack-test-app/Gemfile.lock
+++ b/2.2/test/rack-test-app/Gemfile.lock
@@ -1,14 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (1.5.2)
-    rack-protection (1.5.0)
+    mustermann (1.0.3)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    sinatra (1.4.5)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    tilt (1.4.1)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby

--- a/2.3/test/puma-test-app/Gemfile.lock
+++ b/2.3/test/puma-test-app/Gemfile.lock
@@ -1,16 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    puma (2.8.2)
-      rack (>= 1.1, < 2.0)
-    rack (1.5.2)
-    rack-protection (1.5.0)
+    mustermann (1.0.3)
+    puma (3.12.1)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    sinatra (1.4.5)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    tilt (1.4.1)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -18,3 +19,6 @@ PLATFORMS
 DEPENDENCIES
   puma
   sinatra
+
+BUNDLED WITH
+   1.10.6

--- a/2.3/test/rack-test-app/Gemfile.lock
+++ b/2.3/test/rack-test-app/Gemfile.lock
@@ -1,17 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (1.5.2)
-    rack-protection (1.5.0)
+    mustermann (1.0.3)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    sinatra (1.4.5)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    tilt (1.4.1)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   sinatra
+
+BUNDLED WITH
+   1.10.6

--- a/2.4/test/puma-test-app/Gemfile.lock
+++ b/2.4/test/puma-test-app/Gemfile.lock
@@ -1,16 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    puma (2.8.2)
-      rack (>= 1.1, < 2.0)
-    rack (1.5.2)
-    rack-protection (1.5.0)
+    mustermann (1.0.3)
+    puma (3.12.1)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    sinatra (1.4.5)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    tilt (1.4.1)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -18,3 +19,6 @@ PLATFORMS
 DEPENDENCIES
   puma
   sinatra
+
+BUNDLED WITH
+   1.13.7

--- a/2.4/test/rack-test-app/Gemfile.lock
+++ b/2.4/test/rack-test-app/Gemfile.lock
@@ -1,17 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (1.5.2)
-    rack-protection (1.5.0)
+    mustermann (1.0.3)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    sinatra (1.4.5)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    tilt (1.4.1)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   sinatra
+
+BUNDLED WITH
+   1.13.7

--- a/2.5/test/puma-test-app/Gemfile.lock
+++ b/2.5/test/puma-test-app/Gemfile.lock
@@ -1,17 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mustermann (1.0.1)
-    puma (3.11.2)
-    rack (2.0.4)
-    rack-protection (2.0.0)
+    mustermann (1.0.3)
+    puma (3.12.1)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    sinatra (2.0.0)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    tilt (2.0.8)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -19,3 +19,6 @@ PLATFORMS
 DEPENDENCIES
   puma
   sinatra
+
+BUNDLED WITH
+   1.16.1

--- a/2.5/test/rack-test-app/Gemfile.lock
+++ b/2.5/test/rack-test-app/Gemfile.lock
@@ -1,19 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mustermann (1.0.1)
-    rack (2.0.4)
-    rack-protection (2.0.0)
+    mustermann (1.0.3)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
-    sinatra (2.0.0)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
-    tilt (2.0.8)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   sinatra
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
due to security warnings on some `Gemfile.lock` dependencies.

On RHEL 7 (with preinstalled `openssl`, `rh-ruby2*-ruby-devel` and `rh-ruby2*-rubygem-bundler`), generated using:

```
icom -c -f '*/test/*-test-app' <<EOLX
  rm -v Gemfile.lock
  rm -rf vendor/bundle
  pwd | rev | cut -d'/' -f3 | rev | cut -d'.' -f2 \
    | xargs -i scl enable rh-ruby2{} -- bundle install --path vendor/bundle
EOLX
```
[icom](https://gist.github.com/pvalena/89746f18a328de2f5dad11bf4a386fe5) simply goes through all specified folders and runs the commands in stdin there.