### PR TITLE
Removing Version Typo from Image Stream Descriptions

### DIFF
--- a/imagestreams/ruby-centos7.json
+++ b/imagestreams/ruby-centos7.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Ruby (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major versions updates.",
+          "description": "Build and run Ruby applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
           "supports": "ruby",

--- a/imagestreams/ruby-rhel7-ppc64le.json
+++ b/imagestreams/ruby-rhel7-ppc64le.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Ruby (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major versions updates.",
+          "description": "Build and run Ruby applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
           "iconClass": "icon-ruby",
           "tags": "builder,ruby,ppc64le",
           "supports": "ruby",

--- a/imagestreams/ruby-rhel7.json
+++ b/imagestreams/ruby-rhel7.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Ruby (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major versions updates.",
+          "description": "Build and run Ruby applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
           "supports": "ruby",


### PR DESCRIPTION
This pull request removes a minor typo for all the image stream descriptions.