### PR TITLE
Add support for internal Nexus registry

### DIFF
--- a/2.4/s2i/bin/assemble
+++ b/2.4/s2i/bin/assemble
@@ -26,6 +26,11 @@ mv /tmp/src/* ./
 # Fix source directory permissions
 fix-permissions ./
 
+# Change the npm registry mirror if provided
+if [ -n "$NPM_MIRROR" ]; then
+	npm config set registry $NPM_MIRROR
+fi
+
 echo "---> Building your Ruby application from source ..."
 if [ -f Gemfile ]; then
   ADDTL_BUNDLE_ARGS="--retry 2"

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -37,7 +37,7 @@ container_ip() {
 }
 
 run_s2i_build() {
-  ct_s2i_build_as_df file://${test_dir}/${1}-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp ${s2i_args}
+  ct_s2i_build_as_df file://${test_dir}/${1}-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp ${s2i_args} $(ct_build_s2i_npm_variables)
 }
 
 run_test_application() {

--- a/2.5/s2i/bin/assemble
+++ b/2.5/s2i/bin/assemble
@@ -26,6 +26,11 @@ mv /tmp/src/* ./
 # Fix source directory permissions
 fix-permissions ./
 
+# Change the npm registry mirror if provided
+if [ -n "$NPM_MIRROR" ]; then
+	npm config set registry $NPM_MIRROR
+fi
+
 echo "---> Building your Ruby application from source ..."
 if [ -f Gemfile ]; then
   ADDTL_BUNDLE_ARGS="--retry 2"

--- a/2.5/test/run
+++ b/2.5/test/run
@@ -37,7 +37,7 @@ container_ip() {
 }
 
 run_s2i_build() {
-  ct_s2i_build_as_df file://${test_dir}/${1}-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp ${s2i_args}
+  ct_s2i_build_as_df file://${test_dir}/${1}-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp ${s2i_args} $(ct_build_s2i_npm_variables)
 }
 
 run_test_application() {


### PR DESCRIPTION
Add NPM_MIRROR environment variable as parameter
into run_s2i_build function.
It is added because of we don't want to call registry.nodejs.org
always during testing each PR.
It is valid only if our CA file is present on the host system.
Otherwise we use standard registry (registry.npmjs.org) as before.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>