### PR TITLE
Fixes #225: OpenShift ruby-hello-world deprecated version 2.4

### DIFF
--- a/2.4/test/run
+++ b/2.4/test/run
@@ -137,6 +137,7 @@ test_scl_usage() {
 
 pushd ${test_dir}
 git clone git://github.com/openshift/ruby-hello-world
+cd ruby-hello-world && git checkout d6857ea547c9f7d19d31cfc0355303b059412359 && cd -
 mv ruby-hello-world db-test-app
 popd
 

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -135,10 +135,11 @@ test_scl_usage() {
   fi
 }
 
-pushd ${test_dir}
-git clone git://github.com/openshift/ruby-hello-world
-cd ruby-hello-world && git checkout d6857ea547c9f7d19d31cfc0355303b059412359 && cd -
-mv ruby-hello-world db-test-app
+mkdir -p ${test_dir}/db-test-app
+pushd ${test_dir}/db-test-app
+git clone git://github.com/openshift/ruby-hello-world .
+# Switch to commit which works with ruby-2.4
+git reset --hard d6857ea547c9f7d19d31cfc0355303b059412359
 popd
 
 for server in ${WEB_SERVERS[@]}; do


### PR DESCRIPTION
Upstream repository ruby-hello-world
deprecated all versions except 2.5.
In order to support it again in our s2i-ruby-container as a test suite
after clonning this repository change the commit to
https://github.com/openshift/ruby-hello-world/commit/d6857ea547c9f7d19d31cfc0355303b059412359

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>