### PR TITLE
This commit updates container-common-scripts and fixes npm_test

### DIFF
--- a/2.6/test/run
+++ b/2.6/test/run
@@ -175,12 +175,11 @@ for server in ${WEB_SERVERS[@]}; do
   test_scl_usage "ruby --version" "ruby ${RUBY_VERSION}."
   check_result $?
 
+  ct_npm_works
+  check_result $?
+
   info "All tests for the ${server}-test-app finished successfully."
   cleanup ${server}
 done
-
-info "Testing npm availibility"
-ct_npm_works
-check_result $?
 
 info "All tests finished successfully."


### PR DESCRIPTION
The `container-common-scripts` submodule is updated to the latest changes.

Also, ct_npm_works is fixed. The test needs a container built but in `for` cycle once the ruby application is tested then the ruby container is deleted.

I have added built of a `ruby` application `db` before `ct_npm_works` test.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>