### PR TITLE
[WIP] Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/2.4/test/imagestreams
+++ b/2.4/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams

--- a/2.5/test/imagestreams
+++ b/2.5/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams

--- a/2.6/test/imagestreams
+++ b/2.6/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams

--- a/test/imagestreams
+++ b/test/imagestreams
@@ -1,0 +1,1 @@
+../imagestreams

--- a/test/rails-postgresql-persistent.json
+++ b/test/rails-postgresql-persistent.json
@@ -1,0 +1,1 @@
+../examples/rails-postgresql-persistent.json

--- a/test/rails-postgresql.json
+++ b/test/rails-postgresql.json
@@ -1,0 +1,1 @@
+../examples/rails-postgresql.json

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -23,29 +23,23 @@ ct_os_enable_print_logs
 ct_os_cluster_up
 
 # test with the just built image and an integrated template
-#test_ruby_integration "${IMAGE_NAME}" "${VERSION}" ruby
-
-# test with a released image and an integrated template
-fail_not_released=true
-if [ "${OS}" == "rhel7" ] ; then
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-registry.redhat.io/}rhscl/${BASE_IMAGE_NAME}-${VERSION//./}-rhel7}
-else
-  PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-${REGISTRY:-}centos/${BASE_IMAGE_NAME}-${VERSION//./}-centos7}
-  fail_not_released=false
-fi
-
-#export CT_SKIP_UPLOAD_IMAGE=true
-# Try pulling the image first to see if it is accessible
-if docker pull "${PUBLIC_IMAGE_NAME}"; then
-:
-#  test_ruby_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" ruby
-else
-  echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
-  ! $fail_not_released || false "ERROR: Failed to pull image"
-fi
+test_ruby_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_ruby_imagestream
+
+# test with a released image and an integrated template
+PUBLIC_IMAGE_NAME=${PUBLIC_IMAGE_NAME:-$(ct_get_public_image_name "${OS}" "${BASE_IMAGE_NAME}" "${VERSION}")}
+
+# Try pulling the image first to see if it is accessible
+if docker pull "${PUBLIC_IMAGE_NAME}"; then
+  export CT_SKIP_UPLOAD_IMAGE=true
+  test_ruby_integration "${PUBLIC_IMAGE_NAME}"
+else
+  echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
+  # ignore possible failure of this test for centos images
+  [ "${OS}" == "rhel7" ] && false "ERROR: Failed to pull image"
+fi
 
 OS_TESTSUITE_RESULT=0
 

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -12,16 +12,18 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 source ${THISDIR}/test-lib-ruby.sh
 
-set -exo nounset
+set -eo nounset
 
 trap ct_os_cleanup EXIT SIGINT
 
 ct_os_check_compulsory_vars
 
+ct_os_enable_print_logs
+
 ct_os_cluster_up
 
 # test with the just built image and an integrated template
-test_ruby_integration "${IMAGE_NAME}" "${VERSION}" "${IMAGE_NAME}:${VERSION}"
+#test_ruby_integration "${IMAGE_NAME}" "${VERSION}" ruby
 
 # test with a released image and an integrated template
 fail_not_released=true
@@ -32,16 +34,22 @@ else
   fail_not_released=false
 fi
 
-export CT_SKIP_UPLOAD_IMAGE=true
+#export CT_SKIP_UPLOAD_IMAGE=true
 # Try pulling the image first to see if it is accessible
 if docker pull "${PUBLIC_IMAGE_NAME}"; then
-  test_ruby_integration ruby "${VERSION}" "${PUBLIC_IMAGE_NAME}"
+:
+#  test_ruby_integration "${PUBLIC_IMAGE_NAME}" "${VERSION}" ruby
 else
   echo "Warning: ${PUBLIC_IMAGE_NAME} could not be downloaded via 'docker'"
   ! $fail_not_released || false "ERROR: Failed to pull image"
 fi
 
+# Check the imagestream
+test_ruby_imagestream
+
 OS_TESTSUITE_RESULT=0
 
 ct_os_cluster_down
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,7 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-#test_ruby_integration "${IMAGE_NAME}" ${VERSION} ruby
+test_ruby_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_ruby_imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,12 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_ruby_integration ruby ${VERSION} "${IMAGE_NAME}"
+#test_ruby_integration "${IMAGE_NAME}" ${VERSION} ruby
+
+# Check the imagestream
+test_ruby_imagestream
 
 OS_TESTSUITE_RESULT=0
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/test-lib-ruby.sh
+++ b/test/test-lib-ruby.sh
@@ -13,14 +13,10 @@ source ${THISDIR}/test-lib-openshift.sh
 
 function test_ruby_integration() {
   local image_name=$1
-  local version=$2
-  local import_image=${3:-}
-  VERSION=$version ct_os_test_s2i_app "${image_name}" \
-                                      "https://github.com/sclorg/s2i-ruby-container.git" \
-                                      ${version}/test/puma-test-app \
-                                      ".*" \
-                                      8080 http 200 "" \
-                                      "${import_image}"
+  ct_os_test_s2i_app "${image_name}" \
+                     "https://github.com/sclorg/s2i-ruby-container.git" \
+                     "${VERSION}/test/puma-test-app" \
+                     ".*"
 }
 
 # Check the imagestream

--- a/test/test-lib-ruby.sh
+++ b/test/test-lib-ruby.sh
@@ -23,3 +23,18 @@ function test_ruby_integration() {
                                       "${import_image}"
 }
 
+# Check the imagestream
+function test_ruby_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/ruby-${OS}.json" "${IMAGE_NAME}" \
+                              "https://github.com/sclorg/s2i-ruby-container.git" \
+                              "${VERSION}/test/puma-test-app" \
+                              ".*"
+}
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
+


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster