### PR TITLE
Add libffi-devel to all supported versions

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -35,6 +35,7 @@ LABEL summary="$SUMMARY" \
 
 RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS=" \
+libffi-devel \
 ${RUBY_SCL} \
 ${RUBY_SCL}-ruby-devel \
 ${RUBY_SCL}-rubygem-rake \

--- a/2.5/Dockerfile.fedora
+++ b/2.5/Dockerfile.fedora
@@ -30,7 +30,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install required packages
-RUN INSTALL_PKGS="python2 ruby ruby-devel rubygem-bundler rubygem-rake rubygems-devel redhat-rpm-config" && \
+RUN INSTALL_PKGS="python2 ruby ruby-devel rubygem-bundler rubygem-rake rubygems-devel redhat-rpm-config libffi-devel" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all

--- a/2.5/Dockerfile.rhel7
+++ b/2.5/Dockerfile.rhel7
@@ -37,6 +37,7 @@ LABEL summary="$SUMMARY" \
 RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS=" \
+libffi-devel \
 ${RUBY_SCL} \
 ${RUBY_SCL}-ruby-devel \
 ${RUBY_SCL}-rubygem-rake \

--- a/2.5/Dockerfile.rhel8
+++ b/2.5/Dockerfile.rhel8
@@ -36,6 +36,7 @@ LABEL summary="$SUMMARY" \
 
 RUN yum -y module enable ruby:$RUBY_VERSION && \
     INSTALL_PKGS=" \
+    libffi-devel \
     ruby \
     ruby-devel \
     rubygem-rake \

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -35,6 +35,7 @@ LABEL summary="$SUMMARY" \
 
 RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS=" \
+libffi-devel \
 ${RUBY_SCL} \
 ${RUBY_SCL}-ruby-devel \
 ${RUBY_SCL}-rubygem-rake \

--- a/2.6/Dockerfile.fedora
+++ b/2.6/Dockerfile.fedora
@@ -30,7 +30,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install required packages
-RUN INSTALL_PKGS="python2 ruby ruby-devel rubygem-bundler rubygem-rake rubygems-devel redhat-rpm-config" && \
+RUN INSTALL_PKGS="python2 ruby ruby-devel rubygem-bundler rubygem-rake rubygems-devel redhat-rpm-config libffi-devel" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all

--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -37,6 +37,7 @@ LABEL summary="$SUMMARY" \
 RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS=" \
+libffi-devel \
 ${RUBY_SCL} \
 ${RUBY_SCL}-ruby-devel \
 ${RUBY_SCL}-rubygem-rake \

--- a/2.6/Dockerfile.rhel8
+++ b/2.6/Dockerfile.rhel8
@@ -36,6 +36,7 @@ LABEL summary="$SUMMARY" \
 
 RUN yum -y module enable ruby:$RUBY_VERSION && \
     INSTALL_PKGS=" \
+    libffi-devel \
     ruby \
     ruby-devel \
     rubygem-rake \

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -35,6 +35,7 @@ LABEL summary="$SUMMARY" \
 
 RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS=" \
+libffi-devel \
 ${RUBY_SCL} \
 ${RUBY_SCL}-ruby-devel \
 ${RUBY_SCL}-rubygem-rake \

--- a/2.7/Dockerfile.fedora
+++ b/2.7/Dockerfile.fedora
@@ -30,7 +30,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Install required packages
-RUN INSTALL_PKGS="ruby ruby-devel rubygem-bundler rubygem-rake rubygems-devel redhat-rpm-config" && \
+RUN INSTALL_PKGS="ruby ruby-devel rubygem-bundler rubygem-rake rubygems-devel redhat-rpm-config libffi-devel" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -37,6 +37,7 @@ LABEL summary="$SUMMARY" \
 RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS=" \
+libffi-devel \
 ${RUBY_SCL} \
 ${RUBY_SCL}-ruby-devel \
 ${RUBY_SCL}-rubygem-rake \

--- a/2.7/Dockerfile.rhel8
+++ b/2.7/Dockerfile.rhel8
@@ -36,6 +36,7 @@ LABEL summary="$SUMMARY" \
 
 RUN yum -y module enable ruby:$RUBY_VERSION && \
     INSTALL_PKGS=" \
+    libffi-devel \
     ruby \
     ruby-devel \
     rubygem-rake \


### PR DESCRIPTION
The ffi gem prefers to use a system libffi when the requisite devel is
present, but bundles an (often old) libffi as a fallback.  As only more
recent versions of libffi support newer architectures, this also affects
multi-architecture enablement.

Re: https://github.com/openshift/cluster-samples-operator/pull/225
CC: @gabemontero 