### PR TITLE
Run all tests and report results at the end.

### DIFF
--- a/2.5/test/run
+++ b/2.5/test/run
@@ -161,17 +161,6 @@ function test_base_scl_usage() {
   check_result "$?"
 }
 
-function test_application() {
-  # Verify that the HTTP connection can be established to test application container
-  run_test_application &
-
-  # Wait for the container to write it's CID file
-  wait_for_cid
-
-  test_connection
-  check_result "$?"
-}
-
 function test_npm_functionality() {
   info "Testing npm availibility"
   ct_npm_works
@@ -192,7 +181,10 @@ function run_all_tests() {
       TESTSUITE_RESULT=1
     fi
     printf -v test_short_summary "%s %s for '%s' %s\n" "${test_short_summary}" "${test_msg}" "${APP_NAME}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && cleanup "${APP_NAME}" && return 1
+    [ -n "${FAIL_QUICKLY:-}" ] && {
+      cleanup "${APP_NAME}"
+      return 1
+    }
   done;
 
   cleanup "${APP_NAME}"

--- a/2.5/test/run
+++ b/2.5/test/run
@@ -181,7 +181,7 @@ function test_npm_functionality() {
 function run_all_tests() {
   local APP_NAME="$1"
   for test_case in $TEST_SET; do
-    info "Running test $test_case ...."
+    info "Running test $test_case ... "
     TESTCASE_RESULT=0
     $test_case
     local test_msg
@@ -253,4 +253,3 @@ else
 fi
 
 exit $TESTSUITE_RESULT
-

--- a/2.5/test/run
+++ b/2.5/test/run
@@ -6,7 +6,7 @@
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 #
-IMAGE_NAME=${IMAGE_NAME-centos/ruby-25-centos7-candidate}
+IMAGE_NAME=${IMAGE_NAME-quay.io/centos7/ruby-25-centos7-candidate}
 
 declare -a WEB_SERVERS=(db puma rack)
 #declare -a WEB_SERVERS=(db)
@@ -14,7 +14,18 @@ declare -a WEB_SERVERS=(db puma rack)
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
+test_short_summary=''
+TESTSUITE_RESULT=0
 
+TEST_LIST="\
+test_base_scl_usage
+test_docker_run_usage
+test_application
+test_connection
+test_scl_variables_in_dockerfile
+test_scl_usage
+test_npm_functionality
+"
 source "${test_dir}/test-lib.sh"
 
 # Read exposed port from image meta data
@@ -66,10 +77,9 @@ cleanup() {
 check_result() {
   local result="$1"
   if [[ "$result" != "0" ]]; then
-    info "TEST FAILED (${result})"
-    cleanup
-    exit $result
+    TESTCASE_RESULT=1
   fi
+  return $result
 }
 
 wait_for_cid() {
@@ -88,11 +98,13 @@ wait_for_cid() {
 test_s2i_usage() {
   info "Testing 's2i usage'"
   ct_s2i_usage ${IMAGE_NAME} ${s2i_args} &>/dev/null
+  check_result "$?"
 }
 
 test_docker_run_usage() {
   info "Testing 'docker run' usage"
   docker run ${IMAGE_NAME} &>/dev/null
+  check_result "$?"
 }
 
 test_connection() {
@@ -116,7 +128,7 @@ test_connection() {
   return $result
 }
 
-test_scl_usage() {
+scl_usage() {
   local run_cmd="$1"
   local expected="$2"
 
@@ -136,6 +148,78 @@ test_scl_usage() {
     echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
   fi
+  return 0
+}
+
+function test_scl_usage() {
+  scl_usage "ruby --version" "ruby ${RUBY_VERSION}."
+  check_result "$?"
+}
+
+function test_base_scl_usage() {
+  scl_usage
+  check_result "$?"
+}
+
+function test_application() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_connection
+  check_result "$?"
+}
+
+function test_npm_functionality() {
+  info "Testing npm availibility"
+  ct_npm_works
+  check_result "$?"
+}
+
+function run_all_tests() {
+  local APP_NAME="$1"
+  for test_case in $TEST_SET; do
+    info "Running test $test_case ...."
+    TESTCASE_RESULT=0
+    $test_case
+    local test_msg
+    if [ $TESTCASE_RESULT -eq 0 ]; then
+      test_msg="[PASSED]"
+    else
+      test_msg="[FAILED]"
+      TESTSUITE_RESULT=1
+    fi
+    printf -v test_short_summary "%s %s for '%s' %s\n" "${test_short_summary}" "${test_msg}" "${APP_NAME}" "$test_case"
+    [ -n "${FAIL_QUICKLY:-}" ] && cleanup "${APP_NAME}" && return 1
+  done;
+
+  cleanup "${APP_NAME}"
+}
+
+function test_application() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+}
+
+function test_scl_variables_in_dockerfile() {
+  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
+    # autocleanup only enabled here as only the following tests so far use it
+    CID_FILE_DIR=$(mktemp -d)
+    ct_enable_cleanup
+
+    info "Testing variable presence during \`docker exec\`"
+    ct_check_exec_env_vars
+    check_result $?
+
+    info "Checking if all scl variables are defined in Dockerfile"
+    ct_check_scl_enable_vars
+    check_result $?
+ fi
 }
 
 pushd ${test_dir}
@@ -152,49 +236,21 @@ for server in ${WEB_SERVERS[@]}; do
   # it from Docker hub
   s2i_args="--pull-policy=never"
 
-  run_s2i_build ${server}
+  run_s2i_build "${server}"
   check_result $?
 
-  # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
-  test_s2i_usage
-  check_result $?
+  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "$server"
 
-  # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
-  test_docker_run_usage
-  check_result $?
-
-  # Verify that the HTTP connection can be established to test application container
-  run_test_application &
-
-  # Wait for the container to write it's CID file
-  wait_for_cid
-
-  test_connection
-  check_result $?
-
-  test_scl_usage "ruby --version" "ruby ${RUBY_VERSION}."
-  check_result $?
-
-  info "Testing npm availibility"
-  ct_npm_works
-  check_result $?
-
-  info "All tests for the ${server}-test-app finished successfully."
-  cleanup ${server}
+  cleanup "${server}"
 done
 
-if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-￼  # autocleanup only enabled here as only the following tests so far use it
-   CID_FILE_DIR=$(mktemp -d)
-   ct_enable_cleanup
-￼
-   info "Testing variable presence during \`docker exec\`"
-   ct_check_exec_env_vars
-   check_result $?
-￼
-   info "Checking if all scl variables are defined in Dockerfile"
-   ct_check_scl_enable_vars
-   check_result $?
+echo "$test_short_summary"
+
+if [ $TESTSUITE_RESULT -eq 0 ] ; then
+  echo "Tests for ${IMAGE_NAME} succeeded."
+else
+  echo "Tests for ${IMAGE_NAME} failed."
 fi
 
-info "All tests finished successfully."
+exit $TESTSUITE_RESULT
+

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -192,7 +192,10 @@ function run_all_tests() {
       TESTSUITE_RESULT=1
     fi
     printf -v test_short_summary "%s %s for '%s' %s\n" "${test_short_summary}" "${test_msg}" "${APP_NAME}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && cleanup "${APP_NAME}" && return 1
+    [ -n "${FAIL_QUICKLY:-}" ] && {
+      cleanup "${APP_NAME}"
+      return 1
+    }
   done;
 
   cleanup "${APP_NAME}"
@@ -253,4 +256,3 @@ else
 fi
 
 exit $TESTSUITE_RESULT
-

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -6,7 +6,7 @@
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 #
-IMAGE_NAME=${IMAGE_NAME-centos/ruby-26-centos7-candidate}
+IMAGE_NAME=${IMAGE_NAME-quay.io/centos7/ruby-26-centos7-candidate}
 
 declare -a WEB_SERVERS=(db puma rack)
 #declare -a WEB_SERVERS=(db)
@@ -14,7 +14,18 @@ declare -a WEB_SERVERS=(db puma rack)
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
+test_short_summary=''
+TESTSUITE_RESULT=0
 
+TEST_LIST="\
+test_base_scl_usage
+test_docker_run_usage
+test_application
+test_connection
+test_scl_variables_in_dockerfile
+test_scl_usage
+test_npm_functionality
+"
 source "${test_dir}/test-lib.sh"
 
 # Read exposed port from image meta data
@@ -66,10 +77,9 @@ cleanup() {
 check_result() {
   local result="$1"
   if [[ "$result" != "0" ]]; then
-    info "TEST FAILED (${result})"
-    cleanup
-    exit $result
+    TESTCASE_RESULT=1
   fi
+  return $result
 }
 
 wait_for_cid() {
@@ -88,11 +98,13 @@ wait_for_cid() {
 test_s2i_usage() {
   info "Testing 's2i usage'"
   ct_s2i_usage ${IMAGE_NAME} ${s2i_args} &>/dev/null
+  check_result "$?"
 }
 
 test_docker_run_usage() {
   info "Testing 'docker run' usage"
   docker run ${IMAGE_NAME} &>/dev/null
+  check_result "$?"
 }
 
 test_connection() {
@@ -116,7 +128,7 @@ test_connection() {
   return $result
 }
 
-test_scl_usage() {
+scl_usage() {
   local run_cmd="$1"
   local expected="$2"
 
@@ -136,6 +148,78 @@ test_scl_usage() {
     echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
   fi
+  return 0
+}
+
+function test_scl_usage() {
+  scl_usage "ruby --version" "ruby ${RUBY_VERSION}."
+  check_result "$?"
+}
+
+function test_base_scl_usage() {
+  scl_usage
+  check_result "$?"
+}
+
+function test_application() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_connection
+  check_result "$?"
+}
+
+function test_npm_functionality() {
+  info "Testing npm availibility"
+  ct_npm_works
+  check_result "$?"
+}
+
+function run_all_tests() {
+  local APP_NAME="$1"
+  for test_case in $TEST_SET; do
+    info "Running test $test_case ...."
+    TESTCASE_RESULT=0
+    $test_case
+    local test_msg
+    if [ $TESTCASE_RESULT -eq 0 ]; then
+      test_msg="[PASSED]"
+    else
+      test_msg="[FAILED]"
+      TESTSUITE_RESULT=1
+    fi
+    printf -v test_short_summary "%s %s for '%s' %s\n" "${test_short_summary}" "${test_msg}" "${APP_NAME}" "$test_case"
+    [ -n "${FAIL_QUICKLY:-}" ] && cleanup "${APP_NAME}" && return 1
+  done;
+
+  cleanup "${APP_NAME}"
+}
+
+function test_application() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+}
+
+function test_scl_variables_in_dockerfile() {
+  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
+    # autocleanup only enabled here as only the following tests so far use it
+    CID_FILE_DIR=$(mktemp -d)
+    ct_enable_cleanup
+
+    info "Testing variable presence during \`docker exec\`"
+    ct_check_exec_env_vars
+    check_result $?
+
+    info "Checking if all scl variables are defined in Dockerfile"
+    ct_check_scl_enable_vars
+    check_result $?
+ fi
 }
 
 pushd ${test_dir}
@@ -152,49 +236,21 @@ for server in ${WEB_SERVERS[@]}; do
   # it from Docker hub
   s2i_args="--pull-policy=never"
 
-  run_s2i_build ${server}
+  run_s2i_build "${server}"
   check_result $?
 
-  # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
-  test_s2i_usage
-  check_result $?
+  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "$server"
 
-  # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
-  test_docker_run_usage
-  check_result $?
-
-  # Verify that the HTTP connection can be established to test application container
-  run_test_application &
-
-  # Wait for the container to write it's CID file
-  wait_for_cid
-
-  test_connection
-  check_result $?
-
-  test_scl_usage "ruby --version" "ruby ${RUBY_VERSION}."
-  check_result $?
-
-  info "Testing npm availibility"
-  ct_npm_works
-  check_result $?
-
-  info "All tests for the ${server}-test-app finished successfully."
-  cleanup ${server}
+  cleanup "${server}"
 done
 
-if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-￼  # autocleanup only enabled here as only the following tests so far use it
-   CID_FILE_DIR=$(mktemp -d)
-   ct_enable_cleanup
-￼
-   info "Testing variable presence during \`docker exec\`"
-   ct_check_exec_env_vars
-   check_result $?
-￼
-   info "Checking if all scl variables are defined in Dockerfile"
-   ct_check_scl_enable_vars
-   check_result $?
+echo "$test_short_summary"
+
+if [ $TESTSUITE_RESULT -eq 0 ] ; then
+  echo "Tests for ${IMAGE_NAME} succeeded."
+else
+  echo "Tests for ${IMAGE_NAME} failed."
 fi
 
-info "All tests finished successfully."
+exit $TESTSUITE_RESULT
+

--- a/2.6/test/run
+++ b/2.6/test/run
@@ -161,17 +161,6 @@ function test_base_scl_usage() {
   check_result "$?"
 }
 
-function test_application() {
-  # Verify that the HTTP connection can be established to test application container
-  run_test_application &
-
-  # Wait for the container to write it's CID file
-  wait_for_cid
-
-  test_connection
-  check_result "$?"
-}
-
 function test_npm_functionality() {
   info "Testing npm availibility"
   ct_npm_works
@@ -181,7 +170,7 @@ function test_npm_functionality() {
 function run_all_tests() {
   local APP_NAME="$1"
   for test_case in $TEST_SET; do
-    info "Running test $test_case ...."
+    info "Running test $test_case ... "
     TESTCASE_RESULT=0
     $test_case
     local test_msg

--- a/2.7/test/run
+++ b/2.7/test/run
@@ -161,17 +161,6 @@ function test_base_scl_usage() {
   check_result "$?"
 }
 
-function test_application() {
-  # Verify that the HTTP connection can be established to test application container
-  run_test_application &
-
-  # Wait for the container to write it's CID file
-  wait_for_cid
-
-  test_connection
-  check_result "$?"
-}
-
 function test_npm_functionality() {
   info "Testing npm availibility"
   ct_npm_works
@@ -181,7 +170,7 @@ function test_npm_functionality() {
 function run_all_tests() {
   local APP_NAME="$1"
   for test_case in $TEST_SET; do
-    info "Running test $test_case ...."
+    info "Running test $test_case ... "
     TESTCASE_RESULT=0
     $test_case
     local test_msg
@@ -192,7 +181,10 @@ function run_all_tests() {
       TESTSUITE_RESULT=1
     fi
     printf -v test_short_summary "%s %s for '%s' %s\n" "${test_short_summary}" "${test_msg}" "${APP_NAME}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && cleanup "${APP_NAME}" && return 1
+    [ -n "${FAIL_QUICKLY:-}" ] && {
+      cleanup "${APP_NAME}"
+      return 1
+    }
   done;
 
   cleanup "${APP_NAME}"
@@ -253,4 +245,3 @@ else
 fi
 
 exit $TESTSUITE_RESULT
-

--- a/2.7/test/run
+++ b/2.7/test/run
@@ -6,7 +6,7 @@
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 #
-IMAGE_NAME=${IMAGE_NAME-centos/ruby-27-centos7-candidate}
+IMAGE_NAME=${IMAGE_NAME-quay.io/centos7/ruby-27-centos7-candidate}
 
 declare -a WEB_SERVERS=(db puma rack)
 #declare -a WEB_SERVERS=(db)
@@ -14,7 +14,18 @@ declare -a WEB_SERVERS=(db puma rack)
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
+test_short_summary=''
+TESTSUITE_RESULT=0
 
+TEST_LIST="\
+test_base_scl_usage
+test_docker_run_usage
+test_application
+test_connection
+test_scl_variables_in_dockerfile
+test_scl_usage
+test_npm_functionality
+"
 source "${test_dir}/test-lib.sh"
 
 # Read exposed port from image meta data
@@ -66,10 +77,9 @@ cleanup() {
 check_result() {
   local result="$1"
   if [[ "$result" != "0" ]]; then
-    info "TEST FAILED (${result})"
-    cleanup
-    exit $result
+    TESTCASE_RESULT=1
   fi
+  return $result
 }
 
 wait_for_cid() {
@@ -88,11 +98,13 @@ wait_for_cid() {
 test_s2i_usage() {
   info "Testing 's2i usage'"
   ct_s2i_usage ${IMAGE_NAME} ${s2i_args} &>/dev/null
+  check_result "$?"
 }
 
 test_docker_run_usage() {
   info "Testing 'docker run' usage"
   docker run ${IMAGE_NAME} &>/dev/null
+  check_result "$?"
 }
 
 test_connection() {
@@ -116,7 +128,7 @@ test_connection() {
   return $result
 }
 
-test_scl_usage() {
+scl_usage() {
   local run_cmd="$1"
   local expected="$2"
 
@@ -136,6 +148,78 @@ test_scl_usage() {
     echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
   fi
+  return 0
+}
+
+function test_scl_usage() {
+  scl_usage "ruby --version" "ruby ${RUBY_VERSION}."
+  check_result "$?"
+}
+
+function test_base_scl_usage() {
+  scl_usage
+  check_result "$?"
+}
+
+function test_application() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_connection
+  check_result "$?"
+}
+
+function test_npm_functionality() {
+  info "Testing npm availibility"
+  ct_npm_works
+  check_result "$?"
+}
+
+function run_all_tests() {
+  local APP_NAME="$1"
+  for test_case in $TEST_SET; do
+    info "Running test $test_case ...."
+    TESTCASE_RESULT=0
+    $test_case
+    local test_msg
+    if [ $TESTCASE_RESULT -eq 0 ]; then
+      test_msg="[PASSED]"
+    else
+      test_msg="[FAILED]"
+      TESTSUITE_RESULT=1
+    fi
+    printf -v test_short_summary "%s %s for '%s' %s\n" "${test_short_summary}" "${test_msg}" "${APP_NAME}" "$test_case"
+    [ -n "${FAIL_QUICKLY:-}" ] && cleanup "${APP_NAME}" && return 1
+  done;
+
+  cleanup "${APP_NAME}"
+}
+
+function test_application() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+}
+
+function test_scl_variables_in_dockerfile() {
+  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
+    # autocleanup only enabled here as only the following tests so far use it
+    CID_FILE_DIR=$(mktemp -d)
+    ct_enable_cleanup
+
+    info "Testing variable presence during \`docker exec\`"
+    ct_check_exec_env_vars
+    check_result $?
+
+    info "Checking if all scl variables are defined in Dockerfile"
+    ct_check_scl_enable_vars
+    check_result $?
+ fi
 }
 
 pushd ${test_dir}
@@ -152,49 +236,21 @@ for server in ${WEB_SERVERS[@]}; do
   # it from Docker hub
   s2i_args="--pull-policy=never"
 
-  run_s2i_build ${server}
+  run_s2i_build "${server}"
   check_result $?
 
-  # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
-  test_s2i_usage
-  check_result $?
+  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "$server"
 
-  # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
-  test_docker_run_usage
-  check_result $?
-
-  # Verify that the HTTP connection can be established to test application container
-  run_test_application &
-
-  # Wait for the container to write it's CID file
-  wait_for_cid
-
-  test_connection
-  check_result $?
-
-  test_scl_usage "ruby --version" "ruby ${RUBY_VERSION}."
-  check_result $?
-
-  info "Testing npm availibility"
-  ct_npm_works
-  check_result $?
-
-  info "All tests for the ${server}-test-app finished successfully."
-  cleanup ${server}
+  cleanup "${server}"
 done
 
-if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-￼  # autocleanup only enabled here as only the following tests so far use it
-   CID_FILE_DIR=$(mktemp -d)
-   ct_enable_cleanup
-￼
-   info "Testing variable presence during \`docker exec\`"
-   ct_check_exec_env_vars
-   check_result $?
-￼
-   info "Checking if all scl variables are defined in Dockerfile"
-   ct_check_scl_enable_vars
-   check_result $?
+echo "$test_short_summary"
+
+if [ $TESTSUITE_RESULT -eq 0 ] ; then
+  echo "Tests for ${IMAGE_NAME} succeeded."
+else
+  echo "Tests for ${IMAGE_NAME} failed."
 fi
 
-info "All tests finished successfully."
+exit $TESTSUITE_RESULT
+


### PR DESCRIPTION
Run all tests and report tests at the end

All tests are executed and at the end
results are printed out.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Example report:
```bash
[PASSED] for 'db' test_s2i_usage
[PASSED] for 'db' test_docker_run_usage
[PASSED] for 'db' test_application
[PASSED] for 'db' test_connection
[PASSED] for 'db' test_scl_usage
[PASSED] for 'db' ct_npm_works
[PASSED] for 'puma' test_s2i_usage
[PASSED] for 'puma' test_docker_run_usage
[PASSED] for 'puma' test_application
[PASSED] for 'puma' test_connection
[PASSED] for 'puma' test_scl_usage
[PASSED] for 'puma' ct_npm_works
[PASSED] for 'rack' test_s2i_usage
[PASSED] for 'rack' test_docker_run_usage
[PASSED] for 'rack' test_application
[PASSED] for 'rack' test_connection
[PASSED] for 'rack' test_scl_usage
[PASSED] for 'rack' ct_npm_works

```