### PR TITLE
[DO NOT MERGE before ruby:2.7 is available in RHEL 8] Add 2.7-ubi8 streams

### DIFF
--- a/imagestreams/ruby-centos.json
+++ b/imagestreams/ruby-centos.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Ruby (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.6/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+          "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.7/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
           "supports": "ruby",
@@ -22,7 +22,27 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "2.7-ubi7"
+          "name": "2.7-ubi8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "2.7-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 2.7 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.7/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "supports": "ruby:2.7,ruby",
+          "version": "2.7",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/ruby-27:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/ruby-rhel.json
+++ b/imagestreams/ruby-rhel.json
@@ -29,6 +29,26 @@
         }
       },
       {
+        "name": "2.7-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 2.7 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 2.7 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.7/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "supports": "ruby:2.7,ruby",
+          "version": "2.7",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/ruby-27:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "2.7-ubi7",
         "annotations": {
           "openshift.io/display-name": "Ruby 2.7 (UBI 7)",


### PR DESCRIPTION
Once ruby:2.7 is available in RHEL-8, let's add the stream to the imagestreams.