### PR TITLE
Support testing s2i-ruby-container inside OpenShift 4

### DIFF
--- a/2.5/test/test-lib-remote-openshift.sh
+++ b/2.5/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-remote-openshift.sh

--- a/2.6/test/test-lib-remote-openshift.sh
+++ b/2.6/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-remote-openshift.sh

--- a/2.7/test/test-lib-remote-openshift.sh
+++ b/2.7/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-remote-openshift.sh

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -11,8 +11,11 @@
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 source ${THISDIR}/test-lib-ruby.sh
+source ${THISDIR}/test-lib-remote-openshift.sh
 
 set -eo nounset
+
+ct_os_set_ocp4
 
 trap ct_os_cleanup EXIT SIGINT
 
@@ -20,9 +23,8 @@ ct_os_check_compulsory_vars
 
 oc status || false "It looks like oc is not properly logged in."
 
-export CT_SKIP_NEW_PROJECT=true
-export CT_SKIP_UPLOAD_IMAGE=true
-export CT_NAMESPACE=openshift
+# For testing on OpenShift 4 we use internal registry
+export CT_EXTERNAL_REGISTRY=true
 
 test_ruby_integration "${IMAGE_NAME}"
 

--- a/test/test-lib-remote-openshift.sh
+++ b/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../common/test-lib-remote-openshift.sh


### PR DESCRIPTION
Support testing s2i-ruby-container in OpenShift 4

This commit adds support for testing s2i-ruby-container
in OpenShift 4 environment by [test-openshift-4] comment.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>