### PR TITLE
Add support for Quay.io

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-base-centos7
+FROM quay.io/centos7/s2i-base-centos7
 
 # This image provides a Ruby environment you can use to run your Ruby
 # applications.
@@ -13,7 +13,7 @@ ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
 
 # Set SCL related variables in Dockerfile so that the collection is enabled by default
 ENV RUBY_SCL="rh-ruby${RUBY_SCL_NAME_VERSION}" \
-    IMAGE_NAME="centos/ruby-${RUBY_SCL_NAME_VERSION}-centos7" \
+    IMAGE_NAME="centos7/ruby-${RUBY_SCL_NAME_VERSION}-centos7" \
     SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
     DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
 building and running various Ruby $RUBY_VERSION applications and frameworks. \

--- a/2.5/README.md
+++ b/2.5/README.md
@@ -1,9 +1,9 @@
 Ruby 2.5 container image
-=================
+========================
 This container image includes Ruby 2.5 as a [S2I](https://github.com/openshift/source-to-image) base image for your Ruby 2.5 applications.
 Users can choose between RHEL, CentOS and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -24,7 +24,7 @@ version, that is included in the image; those versions can be changed anytime an
 the nodejs itself is included just to make the npm work.
 
 Usage
----------------------
+-----
 For this, we will assume that you are using the `rhscl/ruby-25-rhel7 image`, available via `ruby:2.5` imagestream tag in Openshift.
 Building a simple [ruby-sample-app](https://github.com/sclorg/s2i-ruby-container/tree/master/2.5/test/puma-test-app) application
 in Openshift can be achieved with the following step:
@@ -75,7 +75,7 @@ file inside your source code repository.
     Set this variable to use a custom RubyGems mirror URL to download required gem packages during build process.
 
 Hot deploy
----------------------
+----------
 In order to dynamically pick up changes made in your application source code, you need to make following steps:
 
 *  **For Ruby on Rails applications**
@@ -107,7 +107,7 @@ After you [podman exec](https://github.com/containers/libpod) into the running c
 directory is set to `/opt/app-root/src`, where the source code is located.
 
 Performance tuning
----------------------
+------------------
 You can tune the number of threads per worker using the
 `PUMA_MIN_THREADS` and `PUMA_MAX_THREADS` environment variables.
 Additionally, the number of worker processes is determined by the number of CPU

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-base-centos7
+FROM quay.io/centos7/s2i-base-centos7
 
 # This image provides a Ruby environment you can use to run your Ruby
 # applications.
@@ -13,7 +13,7 @@ ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
 
 # Set SCL related variables in Dockerfile so that the collection is enabled by default
 ENV RUBY_SCL="rh-ruby${RUBY_SCL_NAME_VERSION}" \
-    IMAGE_NAME="centos/ruby-${RUBY_SCL_NAME_VERSION}-centos7" \
+    IMAGE_NAME="centos7/ruby-${RUBY_SCL_NAME_VERSION}-centos7" \
     SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
     DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
 building and running various Ruby $RUBY_VERSION applications and frameworks. \

--- a/2.6/README.md
+++ b/2.6/README.md
@@ -1,9 +1,9 @@
 Ruby 2.6 container image
-=================
+========================
 This container image includes Ruby 2.6 as a [S2I](https://github.com/openshift/source-to-image) base image for your Ruby 2.6 applications.
 Users can choose between RHEL, CentOS and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -24,7 +24,7 @@ version, that is included in the image; those versions can be changed anytime an
 the nodejs itself is included just to make the npm work.
 
 Usage
----------------------
+-----
 For this, we will assume that you are using the `ubi8/ruby-26 image`, available via `ruby:2.6` imagestream tag in Openshift.
 Building a simple [ruby-sample-app](https://github.com/sclorg/s2i-ruby-container/tree/master/2.6/test/puma-test-app) application
 in Openshift can be achieved with the following step:
@@ -75,7 +75,7 @@ file inside your source code repository.
     Set this variable to use a custom RubyGems mirror URL to download required gem packages during build process.
 
 Hot deploy
----------------------
+----------
 In order to dynamically pick up changes made in your application source code, you need to make following steps:
 
 *  **For Ruby on Rails applications**
@@ -107,7 +107,7 @@ After you [podman exec](https://github.com/containers/libpod) into the running c
 directory is set to `/opt/app-root/src`, where the source code is located.
 
 Performance tuning
----------------------
+------------------
 You can tune the number of threads per worker using the
 `PUMA_MIN_THREADS` and `PUMA_MAX_THREADS` environment variables.
 Additionally, the number of worker processes is determined by the number of CPU

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-base-centos7
+FROM quay.io/centos7/s2i-base-centos7
 
 # This image provides a Ruby environment you can use to run your Ruby
 # applications.
@@ -13,7 +13,7 @@ ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
 
 # Set SCL related variables in Dockerfile so that the collection is enabled by default
 ENV RUBY_SCL="rh-ruby${RUBY_SCL_NAME_VERSION}" \
-    IMAGE_NAME="centos/ruby-${RUBY_SCL_NAME_VERSION}-centos7" \
+    IMAGE_NAME="centos7/ruby-${RUBY_SCL_NAME_VERSION}-centos7" \
     SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
     DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
 building and running various Ruby $RUBY_VERSION applications and frameworks. \

--- a/2.7/README.md
+++ b/2.7/README.md
@@ -1,9 +1,10 @@
 Ruby 2.7 container image
-=================
+========================
+
 This container image includes Ruby 2.7 as a [S2I](https://github.com/openshift/source-to-image) base image for your Ruby 2.7 applications.
 Users can choose between RHEL, CentOS and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -24,7 +25,7 @@ version, that is included in the image; those versions can be changed anytime an
 the nodejs itself is included just to make the npm work.
 
 Usage
----------------------
+-----
 For this, we will assume that you are using the `ubi8/ruby-27 image`, available via `ruby:2.7` imagestream tag in Openshift.
 Building a simple [ruby-sample-app](https://github.com/sclorg/s2i-ruby-container/tree/master/2.7/test/puma-test-app) application
 in Openshift can be achieved with the following step:
@@ -75,7 +76,7 @@ file inside your source code repository.
     Set this variable to use a custom RubyGems mirror URL to download required gem packages during build process.
 
 Hot deploy
----------------------
+----------
 In order to dynamically pick up changes made in your application source code, you need to make following steps:
 
 *  **For Ruby on Rails applications**
@@ -107,7 +108,7 @@ After you [podman exec](https://github.com/containers/libpod) into the running c
 directory is set to `/opt/app-root/src`, where the source code is located.
 
 Performance tuning
----------------------
+------------------
 You can tune the number of threads per worker using the
 `PUMA_MIN_THREADS` and `PUMA_MAX_THREADS` environment variables.
 Additionally, the number of worker processes is determined by the number of CPU

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@ Ruby container images
 ==================
 
 [![Build Status](https://travis-ci.org/sclorg/s2i-ruby-container.svg?branch=master)](https://travis-ci.org/sclorg/s2i-ruby-container)
-[![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-25-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-25-centos7)
-[![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-26-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-26-centos7)
-[![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-27-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-27-centos7)
 
+ruby-25-container status: [![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-25-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-25-centos7)
+
+ruby-26-container status: [![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-26-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-26-centos7)
+
+ruby-27-container status: [![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-27-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-27-centos7)
 
 
 This repository contains the source for building various versions of

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@ Ruby container images
 ==================
 
 [![Build Status](https://travis-ci.org/sclorg/s2i-ruby-container.svg?branch=master)](https://travis-ci.org/sclorg/s2i-ruby-container)
+[![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-25-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-25-centos7)
+[![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-26-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-26-centos7)
+[![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-27-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-27-centos7)
+
 
 
 This repository contains the source for building various versions of
@@ -57,7 +61,7 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ podman pull centos/ruby-27-centos7
+    $ podman pull quay.io/centos7/ruby-27-centos7
     ```
 
     To build a Ruby image from scratch run:

--- a/imagestreams/ruby-centos.json
+++ b/imagestreams/ruby-centos.json
@@ -122,7 +122,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/ruby-26-centos7:latest"
+          "name": "quay.io/centos7/ruby-26-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -182,7 +182,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/ruby-25-centos7:latest"
+          "name": "quay.io/centos7/ruby-25-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
This commit adds support for Quay.io instead of DockerHub.
DockerHub introduced rate limits and therefore we have to move
into Quay.io registry

This PR depends also on:
https://github.com/sclorg/container-common-scripts/pull/181
https://github.com/sclorg/s2i-base-container/pull/205

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>