### PR TITLE
allow ubi8 images to work unauthenticated

### DIFF
--- a/2.5/Dockerfile.rhel8
+++ b/2.5/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM ubi8/s2i-base
+FROM registry.access.redhat.com/ubi8/s2i-base
 
 # This image provides a Ruby environment you can use to run your Ruby
 # applications.

--- a/2.6/Dockerfile.rhel8
+++ b/2.6/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM ubi8/s2i-base
+FROM registry.access.redhat.com/ubi8/s2i-base
 
 # This image provides a Ruby environment you can use to run your Ruby
 # applications.

--- a/2.7/Dockerfile.rhel8
+++ b/2.7/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM ubi8/s2i-base
+FROM registry.access.redhat.com/ubi8/s2i-base
 
 # This image provides a Ruby environment you can use to run your Ruby
 # applications.


### PR DESCRIPTION
Should resolve ubi8 [Issue:306](https://github.com/sclorg/s2i-ruby-container/issues/306).

I didn't check if RHEL7 is having a similar issue but likely it doesn't because we would have heard about it by now.