### PR TITLE
Fix definition of SCL related ENV variables and give ruby SCL bigger priority over nodejs

### DIFF
--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -20,13 +20,12 @@ building and running various Ruby $RUBY_VERSION applications and frameworks. \
 Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
 It has many features to process text files and to do system management tasks (as in Perl). \
 It is simple, straight-forward, and extensible." \
-    PATH=$PATH:/opt/rh/$NODEJS_SCL/root/usr/bin:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/bin:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/bin:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/bin:/opt/rh/$NODEJS_SCL/root/usr/bin \
-    LD_LIBRARY_PATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/lib64:/opt/rh/$NODEJS_SCL/root/usr/lib64:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/lib64 \
-    X_SCLS=$X_SCLS:rh-ruby$RUBY_SCL_NAME_VERSION \
-    MANPATH=/opt/rh/$NODEJS_SCL/root/usr/share/man:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/share/man:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share/man:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/man:/share/man/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share/man:/opt/rh/$NODEJS_SCL/root/usr/share/man \
-    PYTHONPATH=/opt/rh/$NODEJS_SCL/root/usr/lib/python2.7/site-packages \
-    XDG_DATA_DIRS=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/share:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share \
-    PKG_CONFIG_PATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/lib64/pkgconfig
+    PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/bin:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/bin:/opt/rh/${NODEJS_SCL}/root/usr/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64:/opt/rh/${NODEJS_SCL}/root/usr/lib64" \
+    X_SCLS="${NODEJS_SCL} rh-ruby${RUBY_SCL_NAME_VERSION}" \
+    MANPATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share/man:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share/man:/opt/rh/${NODEJS_SCL}/root/usr/share/man:" \
+    XDG_DATA_DIRS="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share:/usr/local/share:/usr/share" \
+    PKG_CONFIG_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64/pkgconfig"
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/2.5/Dockerfile.rhel7
+++ b/2.5/Dockerfile.rhel7
@@ -20,11 +20,12 @@ building and running various Ruby $RUBY_VERSION applications and frameworks. \
 Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
 It has many features to process text files and to do system management tasks (as in Perl). \
 It is simple, straight-forward, and extensible." \
-    PATH=$PATH:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/bin:/opt/rh/$NODEJS_SCL/root/usr/bin \
-    LD_LIBRARY_PATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/lib64:/opt/rh/$NODEJS_SCL/root/usr/lib64 \
-    X_SCLS=rh-ruby$RUBY_SCL_NAME_VERSION \
-    MANPATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share/man:/opt/rh/$NODEJS_SCL/root/usr/share/man \
-    PYTHONPATH=/opt/rh/$NODEJS_SCL/root/usr/lib/python2.7/site-packages
+    PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/bin:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/bin:/opt/rh/${NODEJS_SCL}/root/usr/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64:/opt/rh/${NODEJS_SCL}/root/usr/lib64" \
+    X_SCLS="${NODEJS_SCL} rh-ruby${RUBY_SCL_NAME_VERSION}" \
+    MANPATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share/man:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share/man:/opt/rh/${NODEJS_SCL}/root/usr/share/man:" \
+    XDG_DATA_DIRS="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share:/usr/local/share:/usr/share" \
+    PKG_CONFIG_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64/pkgconfig"
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/2.5/root/opt/app-root/etc/scl_enable
+++ b/2.5/root/opt/app-root/etc/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-ruby25 $NODEJS_SCL
+source scl_source enable $NODEJS_SCL rh-ruby25

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -20,13 +20,13 @@ building and running various Ruby $RUBY_VERSION applications and frameworks. \
 Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
 It has many features to process text files and to do system management tasks (as in Perl). \
 It is simple, straight-forward, and extensible." \
-    PATH=$PATH:/opt/rh/$NODEJS_SCL/root/usr/bin:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/bin:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/bin:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/bin:/opt/rh/$NODEJS_SCL/root/usr/bin \
-    LD_LIBRARY_PATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/lib64:/opt/rh/$NODEJS_SCL/root/usr/lib64:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/lib64 \
-    X_SCLS=$X_SCLS:rh-ruby$RUBY_SCL_NAME_VERSION \
-    MANPATH=/opt/rh/$NODEJS_SCL/root/usr/share/man:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/share/man:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share/man:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/man:/share/man/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share/man:/opt/rh/$NODEJS_SCL/root/usr/share/man \
-    PYTHONPATH=/opt/rh/$NODEJS_SCL/root/usr/lib/python2.7/site-packages \
-    XDG_DATA_DIRS=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/share:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share \
-    PKG_CONFIG_PATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/lib64/pkgconfig
+    PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/bin:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/bin:/opt/rh/${NODEJS_SCL}/root/usr/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64:/opt/rh/${NODEJS_SCL}/root/usr/lib64" \
+    X_SCLS="${NODEJS_SCL} rh-ruby${RUBY_SCL_NAME_VERSION}" \
+    MANPATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share/man:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share/man:/opt/rh/${NODEJS_SCL}/root/usr/share/man:" \
+    XDG_DATA_DIRS="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share:/usr/local/share:/usr/share" \
+    PKG_CONFIG_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64/pkgconfig"
+
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \

--- a/2.6/Dockerfile.rhel7
+++ b/2.6/Dockerfile.rhel7
@@ -20,11 +20,12 @@ building and running various Ruby $RUBY_VERSION applications and frameworks. \
 Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
 It has many features to process text files and to do system management tasks (as in Perl). \
 It is simple, straight-forward, and extensible." \
-    PATH=$PATH:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/bin:/opt/rh/$NODEJS_SCL/root/usr/bin \
-    LD_LIBRARY_PATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/lib64:/opt/rh/$NODEJS_SCL/root/usr/lib64 \
-    X_SCLS=rh-ruby$RUBY_SCL_NAME_VERSION \
-    MANPATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share/man:/opt/rh/$NODEJS_SCL/root/usr/share/man \
-    PYTHONPATH=/opt/rh/$NODEJS_SCL/root/usr/lib/python2.7/site-packages
+    PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/bin:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/bin:/opt/rh/${NODEJS_SCL}/root/usr/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64:/opt/rh/${NODEJS_SCL}/root/usr/lib64" \
+    X_SCLS="${NODEJS_SCL} rh-ruby${RUBY_SCL_NAME_VERSION}" \
+    MANPATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share/man:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share/man:/opt/rh/${NODEJS_SCL}/root/usr/share/man:" \
+    XDG_DATA_DIRS="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share:/usr/local/share:/usr/share" \
+    PKG_CONFIG_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64/pkgconfig"
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/2.6/root/opt/app-root/etc/scl_enable
+++ b/2.6/root/opt/app-root/etc/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-ruby26 $NODEJS_SCL
+source scl_source enable $NODEJS_SCL rh-ruby26

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -20,13 +20,13 @@ building and running various Ruby $RUBY_VERSION applications and frameworks. \
 Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
 It has many features to process text files and to do system management tasks (as in Perl). \
 It is simple, straight-forward, and extensible." \
-    PATH=$PATH:/opt/rh/$NODEJS_SCL/root/usr/bin:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/bin:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/bin:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/bin:/opt/rh/$NODEJS_SCL/root/usr/bin \
-    LD_LIBRARY_PATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/lib64:/opt/rh/$NODEJS_SCL/root/usr/lib64:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/lib64 \
-    X_SCLS=$X_SCLS:rh-ruby$RUBY_SCL_NAME_VERSION \
-    MANPATH=/opt/rh/$NODEJS_SCL/root/usr/share/man:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/share/man:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share/man:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/man:/share/man/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share/man:/opt/rh/$NODEJS_SCL/root/usr/share/man \
-    PYTHONPATH=/opt/rh/$NODEJS_SCL/root/usr/lib/python2.7/site-packages \
-    XDG_DATA_DIRS=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/share:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share \
-    PKG_CONFIG_PATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/lib64/pkgconfig
+    PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/bin:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/bin:/opt/rh/${NODEJS_SCL}/root/usr/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64:/opt/rh/${NODEJS_SCL}/root/usr/lib64" \
+    X_SCLS="${NODEJS_SCL} rh-ruby${RUBY_SCL_NAME_VERSION}" \
+    MANPATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share/man:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share/man:/opt/rh/${NODEJS_SCL}/root/usr/share/man:" \
+    XDG_DATA_DIRS="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share:/usr/local/share:/usr/share" \
+    PKG_CONFIG_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64/pkgconfig"
+
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -20,11 +20,12 @@ building and running various Ruby $RUBY_VERSION applications and frameworks. \
 Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
 It has many features to process text files and to do system management tasks (as in Perl). \
 It is simple, straight-forward, and extensible." \
-    PATH=$PATH:/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/bin:/opt/rh/$NODEJS_SCL/root/usr/bin \
-    LD_LIBRARY_PATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/lib64:/opt/rh/$NODEJS_SCL/root/usr/lib64 \
-    X_SCLS=rh-ruby$RUBY_SCL_NAME_VERSION \
-    MANPATH=/opt/rh/rh-ruby$RUBY_SCL_NAME_VERSION/root/usr/share/man:/opt/rh/$NODEJS_SCL/root/usr/share/man \
-    PYTHONPATH=/opt/rh/$NODEJS_SCL/root/usr/lib/python2.7/site-packages
+    PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/bin:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/bin:/opt/rh/${NODEJS_SCL}/root/usr/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64:/opt/rh/${NODEJS_SCL}/root/usr/lib64" \
+    X_SCLS="${NODEJS_SCL} rh-ruby${RUBY_SCL_NAME_VERSION}" \
+    MANPATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share/man:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share/man:/opt/rh/${NODEJS_SCL}/root/usr/share/man:" \
+    XDG_DATA_DIRS="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/share:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/share:/usr/local/share:/usr/share" \
+    PKG_CONFIG_PATH="/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby${RUBY_SCL_NAME_VERSION}/root/usr/lib64/pkgconfig"
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/2.7/root/opt/app-root/etc/scl_enable
+++ b/2.7/root/opt/app-root/etc/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-ruby27 $NODEJS_SCL
+source scl_source enable $NODEJS_SCL rh-ruby27


### PR DESCRIPTION
One important change is fixing the definition of the environment variables that are related
to SCL. It now more correspond with how it looks like when we just install and enable the Node.js
and Ruby collection.

This should also fix a bug that reported missing ../usr/local/bin path:

  https://bugzilla.redhat.com/show_bug.cgi?id=1909993

Ignoring PYTHONPATH is deliberate as it is set by the Node.js SCL only because of install
dependencies but if one would like to play with Python inside the Ruby container, it might
actually harm, so it's better to keep it unset and let use the system PYTHONPATH.

Swapping SCL names results in the latter having bigger priority, because PATH and other variables
are pre-ended with the new paths and list of SCLs are processed left to right.

Using rh-nodejsX rh-rubyY means that ruby SCL path will be before nodejs path in PATH variable
for example.