### PR TITLE
Deprecate imagestream 2.5 for RHEL7 and CentOS7

### DIFF
--- a/imagestreams/ruby-centos.json
+++ b/imagestreams/ruby-centos.json
@@ -147,46 +147,6 @@
         "referencePolicy": {
           "type": "Local"
         }
-      },
-      {
-        "name": "2.5-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.5 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.5 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:2.5,ruby",
-          "version": "2.5",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi7/ruby-25:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "2.5",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.5",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby,hidden",
-          "supports": "ruby:2.5,ruby",
-          "version": "2.5",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "quay.io/centos7/ruby-25-centos7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
       }
     ]
   }

--- a/imagestreams/ruby-rhel.json
+++ b/imagestreams/ruby-rhel.json
@@ -167,46 +167,6 @@
         "referencePolicy": {
           "type": "Local"
         }
-      },
-      {
-        "name": "2.5-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.5 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.5 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:2.5,ruby",
-          "version": "2.5",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/ruby-25:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "2.5",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.5",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.5 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.5/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby,hidden",
-          "supports": "ruby:2.5,ruby",
-          "version": "2.5",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
       }
     ]
   }


### PR DESCRIPTION
The ruby-2.5 image is going to be EOL in May 2021.