### PR TITLE
[WIP] Add option to update to newer bundler version during assembly

### DIFF
--- a/2.7/README.md
+++ b/2.7/README.md
@@ -160,6 +160,10 @@ file inside your source code repository.
 
     Set this variable to use a custom RubyGems mirror URL to download required gem packages during build process.
 
+* **BUNDLER_VERSION**
+
+    Variable that allows a specific bundler version to be installed, e.g. `2.x.x`.
+
 Hot deploy
 ----------
 In order to dynamically pick up changes made in your application source code, you need to make following steps:

--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -28,6 +28,11 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
+# Ensure specific Bundler version
+if [ -n "BUNDLER_VERSION" ]; then
+  gem install bundler:${BUNDLER_VERSION}
+fi
+
 echo "---> Building your Ruby application from source ..."
 if [ -f Gemfile ]; then
   ADDTL_BUNDLE_ARGS="--retry 2"


### PR DESCRIPTION
Many Ruby applications require a specific version of Bundler. It may be helpful to include a recommendation for how to set the Bundler to a specific version. This is one way to do that.