### PR TITLE
Add Centos Stream 9 Dockerfile for Ruby 3.0

### DIFF
--- a/3.0/Dockerfile.c9s
+++ b/3.0/Dockerfile.c9s
@@ -1,0 +1,63 @@
+FROM quay.io/sclorg/s2i-base-c9s:c9s
+
+# This image provides a Ruby environment you can use to run your Ruby
+# applications.
+
+EXPOSE 8080
+
+ENV RUBY_MAJOR_VERSION=3 \
+    RUBY_MINOR_VERSION=0
+
+ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
+    RUBY_SCL_NAME_VERSION="${RUBY_MAJOR_VERSION}${RUBY_MINOR_VERSION}"
+
+ENV RUBY_SCL="ruby-${RUBY_SCL_NAME_VERSION}" \
+    IMAGE_NAME="ubi8/ruby-${RUBY_SCL_NAME_VERSION}" \
+    SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Ruby ${RUBY_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,ruby,ruby${RUBY_SCL_NAME_VERSION},${RUBY_SCL}" \
+      com.redhat.component="${RUBY_SCL}-container" \
+      name="${IMAGE_NAME}" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      usage="s2i build https://github.com/sclorg/s2i-ruby-container.git \
+--context-dir=${RUBY_VERSION}/test/puma-test-app/ ${IMAGE_NAME} ruby-sample-app" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+RUN INSTALL_PKGS=" \
+    libffi-devel \
+    ruby \
+    ruby-devel \
+    rubygem-rake \
+    rubygem-bundler \
+    redhat-rpm-config \
+    " && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    yum reinstall -y --setopt=tsflags=nodocs tzdata && \
+    yum -y clean all --enablerepo='*' && \
+    rpm -V ${INSTALL_PKGS}
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
+    rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage


### PR DESCRIPTION
This pull request adds support for testing `s2i-ruby-container` in CentOS Stream 9 environment.

What is difference between `Dockerfile.rhel8` and `Dockerfile.c9s` can be seen here:

```bash
$ diff 3.0/Dockerfile.rhel8 3.0/Dockerfile.c9s
1c1
< FROM ubi8/s2i-base
---
> FROM quay.io/sclorg/s2i-base-c9s:c9s
37,38c37
< RUN yum -y module enable ruby:$RUBY_VERSION && \
<     INSTALL_PKGS=" \
---
> RUN INSTALL_PKGS=" \
```