### PR TITLE
Fix git clone security

### DIFF
--- a/test/run
+++ b/test/run
@@ -235,7 +235,7 @@ pushd ${test_dir}
 if [ -d db-test-app ]; then
   rm -rf db-test-app
 fi
-git clone git://github.com/openshift/ruby-hello-world db-test-app
+git clone https://github.com/openshift/ruby-hello-world.git db-test-app
 popd
 
 for server in ${WEB_SERVERS[@]}; do


### PR DESCRIPTION
Based on the Git clone security https://github.blog/2021-09-01-improving-git-protocol-security-github/
let's use https instead of git.