### PR TITLE
Run app-specific assemble script in example Dockerfile

### DIFF
--- a/examples/from-dockerfile/Dockerfile.s2i
+++ b/examples/from-dockerfile/Dockerfile.s2i
@@ -9,7 +9,7 @@ USER 1001
 
 ENV RAILS_ENV=development
 # Install the dependencies
-RUN /usr/libexec/s2i/assemble
+RUN bash -c "/tmp/src/.s2i/bin/assemble || /usr/libexec/s2i/assemble"
 
 # Set the default command for the resulting image
 CMD /usr/libexec/s2i/run


### PR DESCRIPTION
If the s2i app which is build via Dockerfile has it's own s2i assemble script,
execute it instead of the default one. Use the default one as a backup if it fails.

Resolves: #364 