### PR TITLE
Use F35 for Ruby 3.0.

### DIFF
--- a/3.0/Dockerfile.fedora
+++ b/3.0/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f34/s2i-base
+FROM registry.fedoraproject.org/f35/s2i-base
 
 # This image provides a Ruby environment you can use to run your Ruby
 # applications.


### PR DESCRIPTION
Update common submodule commit.

Use F35 for Ruby 3.0.