### PR TITLE
Use f35 for ruby 3.0

### DIFF
--- a/3.0/Dockerfile.fedora
+++ b/3.0/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f34/s2i-base
+FROM quay.io/fedora/s2i-base:35
 
 # This image provides a Ruby environment you can use to run your Ruby
 # applications.


### PR DESCRIPTION
Update common submodule commit.

Use F35 for Ruby 3.0.

Follow up of https://github.com/sclorg/s2i-ruby-container/pull/378