### PR TITLE
Remove Ruby 2.6 imagestreams

### DIFF
--- a/imagestreams/ruby-centos.json
+++ b/imagestreams/ruby-centos.json
@@ -128,66 +128,6 @@
         }
       },
       {
-        "name": "2.6-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.6 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:2.6,ruby",
-          "version": "2.6",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/ruby-26:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "2.6-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.6 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.6 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:2.6,ruby",
-          "version": "2.6",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi7/ruby-26:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "2.6",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.6",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.6 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby,hidden",
-          "supports": "ruby:2.6,ruby",
-          "version": "2.6",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "quay.io/centos7/ruby-26-centos7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "2.5-ubi8",
         "annotations": {
           "openshift.io/display-name": "Ruby 2.5 (UBI 8)",

--- a/imagestreams/ruby-rhel-aarch64.json
+++ b/imagestreams/ruby-rhel-aarch64.json
@@ -69,26 +69,6 @@
         }
       },
       {
-        "name": "2.6-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.6 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:2.6,ruby",
-          "version": "2.6",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/ruby-26:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "2.5-ubi8",
         "annotations": {
           "openshift.io/display-name": "Ruby 2.5 (UBI 8)",

--- a/imagestreams/ruby-rhel.json
+++ b/imagestreams/ruby-rhel.json
@@ -129,66 +129,6 @@
         }
       },
       {
-        "name": "2.6-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.6 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.6 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:2.6,ruby",
-          "version": "2.6",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/ruby-26:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "2.6-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.6 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.6 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:2.6,ruby",
-          "version": "2.6",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/ruby-26:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "2.6",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 2.6",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 2.6 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.6/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby,hidden",
-          "supports": "ruby:2.6,ruby",
-          "version": "2.6",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/ruby-26-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "2.5-ubi8",
         "annotations": {
           "openshift.io/display-name": "Ruby 2.5 (UBI 8)",


### PR DESCRIPTION
RHEL 7 Ruby 2.6 retirement: May 2022
RHEL 8 Ruby 2.6 retirement: Mar 2022

https://access.redhat.com/support/policy/updates/rhscl-rhel7
https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle
