### PR TITLE
Support building and testing ruby-3.0 on RHEL9

### DIFF
--- a/3.0/Dockerfile.rhel9
+++ b/3.0/Dockerfile.rhel9
@@ -1,0 +1,62 @@
+FROM ubi9/s2i-base
+
+# This image provides a Ruby environment you can use to run your Ruby
+# applications.
+
+EXPOSE 8080
+
+ENV RUBY_MAJOR_VERSION=3 \
+    RUBY_MINOR_VERSION=0
+
+ENV RUBY_VERSION="${RUBY_MAJOR_VERSION}.${RUBY_MINOR_VERSION}" \
+    RUBY_SCL_NAME_VERSION="${RUBY_MAJOR_VERSION}${RUBY_MINOR_VERSION}"
+
+ENV RUBY_SCL="ruby-${RUBY_SCL_NAME_VERSION}" \
+    IMAGE_NAME="ubi9/ruby-${RUBY_SCL_NAME_VERSION}" \
+    SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
+    DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
+building and running various Ruby $RUBY_VERSION applications and frameworks. \
+Ruby is the interpreted scripting language for quick and easy object-oriented programming. \
+It has many features to process text files and to do system management tasks (as in Perl). \
+It is simple, straight-forward, and extensible."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Ruby ${RUBY_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,ruby,ruby${RUBY_SCL_NAME_VERSION},${RUBY_SCL}" \
+      com.redhat.component="${RUBY_SCL}-container" \
+      name="${IMAGE_NAME}" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      usage="s2i build https://github.com/sclorg/s2i-ruby-container.git \
+--context-dir=${RUBY_VERSION}/test/puma-test-app/ ${IMAGE_NAME} ruby-sample-app" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+RUN INSTALL_PKGS=" \
+    libffi-devel \
+    ruby \
+    ruby-devel \
+    rubygem-rake \
+    rubygem-bundler \
+    redhat-rpm-config \
+    " && \
+    yum install -y --setopt=tsflags=nodocs ${INSTALL_PKGS} && \
+    yum -y clean all --enablerepo='*' && \
+    rpm -V ${INSTALL_PKGS}
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
+    rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -4,7 +4,7 @@ This container image includes Ruby 3.0 as a [S2I](https://github.com/openshift/s
 Users can choose between RHEL, CentOS and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
 the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
-and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
+and the Fedora images are available in [Quay.io](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
 Note: while the examples in this README are calling `podman`, you can replace any such calls by `docker` with the same arguments
@@ -226,4 +226,4 @@ See also
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-ruby-container.
 In that repository you also can find another versions of Ruby environment Dockerfiles.
 Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
+for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 Ruby container images
 ==================
 
-[![Build Status](https://travis-ci.org/sclorg/s2i-ruby-container.svg?branch=master)](https://travis-ci.org/sclorg/s2i-ruby-container)
+[![Build and push images to Quay.io registry](https://github.com/sclorg/s2i-ruby-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/s2i-ruby-container/actions/workflows/build-and-push.yml)
 
-ruby-27-container status: [![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-27-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-27-centos7)
-
-ruby-30-container status: [![Docker Repository on Quay](https://quay.io/repository/centos7/ruby-30-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/ruby-30-centos7)
-
+Images available on Quay are:
+* CentOS 7 [ruby-25](https://quay.io/repository/centos7/ruby-25-centos7)
+* CentOS 7 [ruby-26](https://quay.io/repository/centos7/ruby-26-centos7)
+* CentOS 7 [ruby-27](https://quay.io/repository/centos7/ruby-27-centos7)
+* CentOS 7 [ruby-30](https://quay.io/repository/centos7/ruby-30-centos7)
+* Fedora [ruby-30](https://quay.io/repository/fedora/ruby-30)
 
 This repository contains the source for building various versions of
 the Ruby application as a reproducible container image using
@@ -27,9 +29,11 @@ Ruby versions currently provided are:
 RHEL versions currently supported are:
 * RHEL7
 * RHEL8
+* RHEL9
 
 CentOS versions currently supported are:
 * CentOS7
+* CentOS Stream 9
 
 A Ruby 1.9 image can be built from [this third party repository](https://github.com/getupcloud/s2i-ruby/).
 It is not maintained by Red Hat nor is part of the OpenShift project.


### PR DESCRIPTION
This pull request adds support for building, testing ruby-3.0 container on RHEL9 host.

It also updates README.md with proper references.

