### PR TITLE
tests: use generic function from test-lib where possible

### DIFF
--- a/test/run
+++ b/test/run
@@ -14,8 +14,6 @@ declare -a WEB_SERVERS=(db puma rack)
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -f $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -f ${test_dir}/..)
-test_short_summary=''
-TESTSUITE_RESULT=0
 
 TEST_LIST="\
 test_docker_run_usage
@@ -26,6 +24,7 @@ test_scl_usage
 test_npm_functionality
 "
 source "${test_dir}/test-lib.sh"
+trap "ct_cleanup;_cleanup" EXIT SIGINT
 
 # Read exposed port from image meta data
 test_port="$(docker inspect --format='{{range $key, $value := .Config.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"
@@ -54,20 +53,16 @@ run_test_application() {
   docker run --user=100001 --rm --cidfile=${cid_file} ${IMAGE_NAME}-testapp
 }
 
-cleanup() {
-  local server="$1"
+_cleanup() {
   info "Cleaning up the test application image $1"
-  if [ -f $cid_file ]; then
-    if container_exists; then
-      docker stop $(cat $cid_file)
-    fi
-  fi
   if image_exists ${IMAGE_NAME}-testapp; then
     docker rmi -f ${IMAGE_NAME}-testapp
   fi
-  if [ ! -z "${server}" ]; then
-    rm -rf ${test_dir}/${server}-test-app/.git
-  fi
+  for server in ${WEB_SERVERS[*]}; do
+    if [ ! -z "${server}" ]; then
+      rm -rf ${test_dir}/${server}-test-app/.git
+    fi
+  done
   if [[ "${server}" == "db" ]]; then
     rm -rf ${test_dir}/db-test-app
   fi
@@ -79,22 +74,6 @@ check_result() {
     TESTCASE_RESULT=1
   fi
   return $result
-}
-
-wait_for_cid() {
-  local max_attempts=10
-  local sleep_time=1
-  local attempt=1
-  local result=1
-  info "Waiting for application container to start"
-  while [ $attempt -le $max_attempts ]; do
-    [ -f $cid_file ] && [ -s $cid_file ] && break
-    attempt=$(( $attempt + 1 ))
-    sleep $sleep_time
-  done
-  if [ $attempt -gt $max_attempts ]; then
-    return 1
-  fi
 }
 
 test_s2i_usage() {
@@ -165,53 +144,17 @@ function test_npm_functionality() {
   check_result "$?"
 }
 
-function handle_test_case_result() {
-    local output_format
-    output_format="%s %s $1\n"
-    shift
-    local test_msg
-    if [ $TESTCASE_RESULT -eq 0 ]; then
-      test_msg="[PASSED]"
-    else
-      test_msg="[FAILED]"
-      TESTSUITE_RESULT=1
-    fi
-    printf -v test_short_summary "${output_format}" "${test_short_summary}" "${test_msg}" $@
-}
-
-function run_all_tests() {
-  local APP_NAME="$1"
-  for test_case in $TEST_SET; do
-    info "Running test $test_case ... "
-    TESTCASE_RESULT=0
-    $test_case
-    check_result $?
-    local test_msg
-    handle_test_case_result "for '%s' %s" "${APP_NAME}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && {
-      cleanup "${APP_NAME}"
-      return 1
-    }
-  done;
-
-  cleanup "${APP_NAME}"
-}
-
 function test_application() {
   # Verify that the HTTP connection can be established to test application container
   run_test_application &
 
   # Wait for the container to write it's CID file
-  wait_for_cid
+  ct_wait_for_cid "${cid_file}"
   check_result $?
 }
 
 function test_scl_variables_in_dockerfile() {
   if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-    # autocleanup only enabled here as only the following tests so far use it
-    CID_FILE_DIR=$(mktemp -d)
-    ct_enable_cleanup
-
     info "Testing variable presence during \`docker exec\`"
     ct_check_exec_env_vars
     check_result $?
@@ -228,7 +171,10 @@ function test_from_dockerfile() {
   info "Check building using a $dockerfile"
   ct_test_app_dockerfile $test_dir/examples/from-dockerfile/$dockerfile 'https://github.com/sclorg/rails-ex.git' 'Welcome to your Rails application on OpenShift' app-src
   check_result $?
-  handle_test_case_result "test_from_dockerfile for %s" "${dockerfile}"
+}
+
+function test_from_dockerfile_s2i() {
+  test_from_dockerfile ".s2i"
 }
 
 pushd ${test_dir}
@@ -238,32 +184,19 @@ fi
 git clone https://github.com/openshift/ruby-hello-world.git db-test-app
 popd
 
+TEST_SUMMARY=''
+CID_FILE_DIR=$(mktemp -d)
 for server in ${WEB_SERVERS[@]}; do
-  cid_file=$(mktemp -u --suffix=.cid)
-
+  cid_file=$CID_FILE_DIR/$(mktemp -u -p . --suffix=.cid)
   # Since we built the candidate image locally, we don't want S2I attempt to pull
   # it from Docker hub
   s2i_args="--pull-policy=never"
 
-  TESTCASE_RESULT=0
   run_s2i_build "${server}"
   check_result $?
-  handle_test_case_result "build of '%s' app" "${server}"
 
-  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "$server"
-
-  cleanup "${server}"
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "$server"
 done
 
-test_from_dockerfile
-test_from_dockerfile ".s2i"
-
-echo "$test_short_summary"
-
-if [ $TESTSUITE_RESULT -eq 0 ] ; then
-  echo "Tests for ${IMAGE_NAME} succeeded."
-else
-  echo "Tests for ${IMAGE_NAME} failed."
-fi
-
-exit $TESTSUITE_RESULT
+TEST_LIST="test_from_dockerfile test_from_dockerfile_s2i"
+TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "from_dockerfile"


### PR DESCRIPTION
- the run_all_tests and handle_test_case_result
  functions removed, as their functionality is contained
  in ct_run_tests_from_testset and ct_cleanup functions
- wait_for_cid removed and used the one from test-lib.sh
- cleanup function called at EXIT and SIGINT together with ct_cleanup
  function. ct_cleanup partially takes over local cleanup
  responsibility, as it cleans containers and CIDs in $CID_FILE_DIR
- test_from_dockerfile split to 2 functions, as the
  ct_run_all_tests_from_testset does not allow parametrized tests