### PR TITLE
Fix #422: Allow testing on RHEL8

### DIFF
--- a/test/test-lib-ruby.sh
+++ b/test/test-lib-ruby.sh
@@ -21,7 +21,7 @@ function test_ruby_integration() {
 # Check the imagestream
 function test_ruby_imagestream() {
   case ${OS} in
-    rhel7|centos7) ;;
+    rhel7|centos7|rhel8) ;;
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 


### PR DESCRIPTION
This pull request fixes OpenShift 4 tests on RHEL8 and RHEL9 hosts

Closes #422

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>