### PR TITLE
Add support for testing ruby-container in CVP pipeline

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -10,8 +10,8 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-source ${THISDIR}/test-lib-ruby.sh
-source ${THISDIR}/test-lib-remote-openshift.sh
+source "${THISDIR}/test-lib-ruby.sh"
+source "${THISDIR}/test-lib-remote-openshift.sh"
 
 TEST_LIST="\
 test_ruby_integration
@@ -25,6 +25,8 @@ trap ct_os_cleanup EXIT SIGINT
 ct_os_check_compulsory_vars
 
 ct_os_check_login || exit 1
+
+ct_os_tag_image_for_cvp "ruby"
 
 set -u
 

--- a/test/test-openshift.yaml
+++ b/test/test-openshift.yaml
@@ -1,0 +1,1 @@
+../common/test-openshift.yaml


### PR DESCRIPTION
This pull request adds support for testing ruby-container in CVP pipeline.
As soon as the container is built, then CVP pipeline triggers build
and execute as sanity checks and functional tests.

What is changed in this pull request:
* `common` directory is updated to the latest
* `run-openshift-remote-cluster` added function for tagging ruby image
* allow testing imagestreams also for RHEL8


Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>