### PR TITLE
Fix symlink location from test to common dir

### DIFF
--- a/2.5/test/test-lib-openshift.sh
+++ b/2.5/test/test-lib-openshift.sh
@@ -1,1 +1,1 @@
-../../test/test-lib-openshift.sh
+../../common/test-lib-openshift.sh

--- a/2.7/test/test-lib-openshift.sh
+++ b/2.7/test/test-lib-openshift.sh
@@ -1,1 +1,1 @@
-../../test/test-lib-openshift.sh
+../../common/test-lib-openshift.sh

--- a/3.0/test/test-lib-openshift.sh
+++ b/3.0/test/test-lib-openshift.sh
@@ -1,1 +1,1 @@
-../../test/test-lib-openshift.sh
+../../common/test-lib-openshift.sh

--- a/3.1/test/test-lib-openshift.sh
+++ b/3.1/test/test-lib-openshift.sh
@@ -1,1 +1,1 @@
-../../test/test-lib-openshift.sh
+../../common/test-lib-openshift.sh


### PR DESCRIPTION
Replace location `test-lib-openshift.sh` from `test` directory to `common` directory

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>