### PR TITLE
Support testing imagestreams on RHEL9

### DIFF
--- a/test/test-lib-ruby.sh
+++ b/test/test-lib-ruby.sh
@@ -8,8 +8,8 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-source ${THISDIR}/test-lib.sh
-source ${THISDIR}/test-lib-openshift.sh
+source "${THISDIR}/test-lib.sh"
+source "${THISDIR}/test-lib-openshift.sh"
 
 function test_ruby_integration() {
   ct_os_test_s2i_app "${IMAGE_NAME}" \
@@ -21,7 +21,7 @@ function test_ruby_integration() {
 # Check the imagestream
 function test_ruby_imagestream() {
   case ${OS} in
-    rhel7|centos7|rhel8) ;;
+    rhel7|centos7|rhel8|rhel9) ;;
     *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
   esac
 


### PR DESCRIPTION
This pull request adds support for testing imagestreams on RHEL9 host in OpenShift 4 environment.