### PR TITLE
Proper cleanup

### DIFF
--- a/test/run
+++ b/test/run
@@ -52,7 +52,7 @@ run_test_application() {
   docker run --user=100001 --rm --cidfile=${cid_file} ${IMAGE_NAME}-testapp
 }
 
-check_result() {
+ct_check_testcase_result() {
   local result="$1"
   if [[ "$result" != "0" ]]; then
     TESTCASE_RESULT=1
@@ -63,13 +63,13 @@ check_result() {
 test_s2i_usage() {
   info "Testing 's2i usage'"
   ct_s2i_usage ${IMAGE_NAME} ${s2i_args} &>/dev/null
-  check_result "$?"
+  ct_check_testcase_result "$?"
 }
 
 test_docker_run_usage() {
   info "Testing 'docker run' usage"
   docker run ${IMAGE_NAME} &>/dev/null
-  check_result "$?"
+  ct_check_testcase_result "$?"
 }
 
 test_connection() {
@@ -119,13 +119,13 @@ scl_usage() {
 
 function test_scl_usage() {
   scl_usage "ruby --version" "ruby ${RUBY_VERSION}."
-  check_result "$?"
+  ct_check_testcase_result "$?"
 }
 
 function test_npm_functionality() {
   info "Testing npm availibility"
   ct_npm_works
-  check_result "$?"
+  ct_check_testcase_result "$?"
 }
 
 function test_application() {
@@ -134,18 +134,18 @@ function test_application() {
 
   # Wait for the container to write it's CID file
   ct_wait_for_cid "${cid_file}"
-  check_result $?
+  ct_check_testcase_result $?
 }
 
 function test_scl_variables_in_dockerfile() {
   if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
     info "Testing variable presence during \`docker exec\`"
     ct_check_exec_env_vars
-    check_result $?
+    ct_check_testcase_result $?
 
     info "Checking if all scl variables are defined in Dockerfile"
     ct_check_scl_enable_vars
-    check_result $?
+    ct_check_testcase_result $?
  fi
 }
 
@@ -154,7 +154,7 @@ function test_from_dockerfile() {
   TESTCASE_RESULT=0
   info "Check building using a $dockerfile"
   ct_test_app_dockerfile $test_dir/examples/from-dockerfile/$dockerfile 'https://github.com/sclorg/rails-ex.git' 'Welcome to your Rails application on OpenShift' app-src
-  check_result $?
+  ct_check_testcase_result $?
 }
 
 function test_from_dockerfile_s2i() {
@@ -188,7 +188,7 @@ for server in ${WEB_SERVERS[@]}; do
   s2i_args="--pull-policy=never"
 
   run_s2i_build "${server}"
-  check_result $?
+  ct_check_testcase_result $?
 
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "$server"
 done

--- a/test/run
+++ b/test/run
@@ -68,7 +68,7 @@ test_s2i_usage() {
 
 test_docker_run_usage() {
   info "Testing 'docker run' usage"
-  docker run ${IMAGE_NAME} &>/dev/null
+  docker run --rm ${IMAGE_NAME} &>/dev/null
   ct_check_testcase_result "$?"
 }
 

--- a/test/run
+++ b/test/run
@@ -24,7 +24,6 @@ test_scl_usage
 test_npm_functionality
 "
 source "${test_dir}/test-lib.sh"
-trap "ct_cleanup;_cleanup" EXIT SIGINT
 
 # Read exposed port from image meta data
 test_port="$(docker inspect --format='{{range $key, $value := .Config.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"
@@ -51,21 +50,6 @@ run_s2i_build() {
 
 run_test_application() {
   docker run --user=100001 --rm --cidfile=${cid_file} ${IMAGE_NAME}-testapp
-}
-
-_cleanup() {
-  info "Cleaning up the test application image $1"
-  if image_exists ${IMAGE_NAME}-testapp; then
-    docker rmi -f ${IMAGE_NAME}-testapp
-  fi
-  for server in ${WEB_SERVERS[*]}; do
-    if [ ! -z "${server}" ]; then
-      rm -rf ${test_dir}/${server}-test-app/.git
-    fi
-  done
-  if [[ "${server}" == "db" ]]; then
-    rm -rf ${test_dir}/db-test-app
-  fi
 }
 
 check_result() {
@@ -177,6 +161,17 @@ function test_from_dockerfile_s2i() {
   test_from_dockerfile ".s2i"
 }
 
+app_cleanup() {
+  for server in ${WEB_SERVERS[*]}; do
+    if [ ! -z "${server}" ]; then
+      rm -rf ${test_dir}/${server}-test-app/.git
+    fi
+  done
+  if [[ "${server}" == "db" ]]; then
+    rm -rf ${test_dir}/db-test-app
+  fi
+}
+
 pushd ${test_dir}
 if [ -d db-test-app ]; then
   rm -rf db-test-app
@@ -184,8 +179,8 @@ fi
 git clone https://github.com/openshift/ruby-hello-world.git db-test-app
 popd
 
-TEST_SUMMARY=''
-CID_FILE_DIR=$(mktemp -d)
+ct_init
+
 for server in ${WEB_SERVERS[@]}; do
   cid_file=$CID_FILE_DIR/$(mktemp -u -p . --suffix=.cid)
   # Since we built the candidate image locally, we don't want S2I attempt to pull
@@ -200,3 +195,5 @@ done
 
 TEST_LIST="test_from_dockerfile test_from_dockerfile_s2i"
 TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "from_dockerfile"
+
+app_cleanup


### PR DESCRIPTION
Use `ct_init` function for preparing the test environment.
Use generic function for checking the testcase result.
Remove usage container when it finishes.