### PR TITLE
remove ruby 2.6 from build-and-push, as it is already EOLed

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -14,13 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dockerfile: "2.6/Dockerfile"
-            registry_namespace: "centos7"
-            tag: "centos7"
-            image_name: "ruby-26-centos7"
-            docker_context: "2.6"
-            quayio_username: "QUAY_IMAGE_BUILDER_USERNAME"
-            quayio_token: "QUAY_IMAGE_BUILDER_TOKEN"
           - dockerfile: "2.7/Dockerfile"
             registry_namespace: "centos7"
             tag: "centos7"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Ruby container images
 
 Images available on Quay are:
 * CentOS 7 [ruby-25](https://quay.io/repository/centos7/ruby-25-centos7)
-* CentOS 7 [ruby-26](https://quay.io/repository/centos7/ruby-26-centos7)
 * CentOS 7 [ruby-27](https://quay.io/repository/centos7/ruby-27-centos7)
 * CentOS 7 [ruby-30](https://quay.io/repository/centos7/ruby-30-centos7)
 * Fedora [ruby-30](https://quay.io/repository/fedora/ruby-30)


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
