### PR TITLE
Compare VERSION with sort for rails-ex branching.

### DIFF
--- a/test/run
+++ b/test/run
@@ -159,11 +159,10 @@ function test_from_dockerfile() {
   # we can use the same Gemfile for RHEL 7 and newer
   # as long as Ruby MAJOR.MINOR <= 3.1. Newer Ruby needs dependencies
   # that are not compatible with RHEL 7.
-  ruby_major=$(echo "$VERSION" | cut -d'.' -f1)
-  ruby_minor=$(echo "$VERSION" | cut -d'.' -f2)
+
   # Latest stable
   rails_example_repo_branch="3.3"
-  if [[ "$ruby_major" -le 3 ]] && [[ "$ruby_minor" -le 1 ]]; then
+  if { echo "$VERSION"; echo "3.1"; } | sort --version-sort --check=quiet; then
     # Ruby 3.1 and prior.
     rails_example_repo_branch="master"
   fi

--- a/test/test-lib-ruby.sh
+++ b/test/test-lib-ruby.sh
@@ -35,11 +35,10 @@ function rails_ex_branch() {
   # we can use the same Gemfile for RHEL 7 and newer
   # as long as Ruby MAJOR.MINOR <= 3.1. Newer Ruby needs dependencies
   # that are not compatible with RHEL 7.
-  ruby_major=$(echo "$VERSION" | cut -d'.' -f1)
-  ruby_minor=$(echo "$VERSION" | cut -d'.' -f2)
+
   # Latest stable
   rails_example_repo_branch="3.3"
-  if [[ "$ruby_major" -le 3 ]] && [[ "$ruby_minor" -le 1 ]]; then
+  if { echo "$VERSION"; echo "3.1"; } | sort --version-sort --check=quiet; then
     # Ruby 3.1 and prior.
     rails_example_repo_branch="master"
   fi


### PR DESCRIPTION
Comparing the minor version when split with a dot will result in 2.5 being bigger than 3.1, since in the comparison the 5 is bigger than 1.

Fixup of the condition in #518 

This time I was able to verify that 2.5 is indeed smaller than 3.1. And that 3.1 is less than or equal to 3.1