### PR TITLE
Chown the directories added into container in test_from_dockerfile.

### DIFF
--- a/examples/from-dockerfile/Dockerfile
+++ b/examples/from-dockerfile/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubi8/ruby-27
 
-ADD app-src ./
+ADD --chown=default:root app-src ./
 
 RUN bundle install --path ./bundle
 

--- a/examples/from-dockerfile/Dockerfile
+++ b/examples/from-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubi8/ruby-27
+FROM ubi8/ruby-31
 
 ADD --chown=default:root app-src ./
 

--- a/examples/from-dockerfile/Dockerfile.s2i
+++ b/examples/from-dockerfile/Dockerfile.s2i
@@ -1,4 +1,4 @@
-FROM ubi8/ruby-27
+FROM ubi8/ruby-31
 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access


### PR DESCRIPTION
Since bundler v2.5.0, if the `frozen` option is not specified via CLI or config, bundler will 'touch' the Gemfile.lock to update timestamps. This will fail in test_from_dockerfile since the app-src is added into the container with ownership of root:root.

Ideally, we expect the directory is writeable, so adjust ownership via the Containerfile ADD --chown=<user>:<group> instruction.

Commit in bundler that introduced this behavior:
https://github.com/rubygems/rubygems/commit/b08f2f1208137c88f978500a281f5a74ee0aae02

Fixes for 3.3 test_from_dockerfile tests in #507 .

There are other alternatives, such as adding the --frozen, however supplying that is deprecated, so there would need to be an additional step that would use set and then we are depending on the behavior of bundler, which I personally don't like. I find it better to just own the directory. Other alternative is just chowning Gemfile.lock and leave the rest of the directory be.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
