### PR TITLE
do not set VERSION env var in Fedora Container files

### DIFF
--- a/2.7/Dockerfile.fedora
+++ b/2.7/Dockerfile.fedora
@@ -7,8 +7,7 @@ EXPOSE 8080
 
 ENV NAME=ruby \
     RUBY_VERSION=2.7 \
-    RUBY_SHORT_VER=27 \
-    VERSION=0
+    RUBY_SHORT_VER=27
 
 ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
     DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
@@ -25,7 +24,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,ruby,ruby${RUBY_SHORT_VER}" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
-      version="$VERSION" \
+      version=0 \
       usage="s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=${RUBY_VERSION}/test/puma-test-app/ registry.fedoraproject.org/$FGC/ruby ruby-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/3.0/Dockerfile.fedora
+++ b/3.0/Dockerfile.fedora
@@ -7,8 +7,7 @@ EXPOSE 8080
 
 ENV NAME=ruby \
     RUBY_VERSION=3.0 \
-    RUBY_SHORT_VER=30 \
-    VERSION=0
+    RUBY_SHORT_VER=30
 
 ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
     DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
@@ -25,7 +24,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,ruby,ruby${RUBY_SHORT_VER}" \
       com.redhat.component="$NAME" \
       name="fedora/$NAME-$RUBY_SHORT_VER" \
-      version="$VERSION" \
+      version=0 \
       usage="s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=${RUBY_VERSION}/test/puma-test-app/ quay.io/fedora/$NAME-$RUBY_SHORT_VER ruby-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/3.1/Dockerfile.fedora
+++ b/3.1/Dockerfile.fedora
@@ -7,8 +7,7 @@ EXPOSE 8080
 
 ENV NAME=ruby \
     RUBY_VERSION=3.1 \
-    RUBY_SHORT_VER=31 \
-    VERSION=0
+    RUBY_SHORT_VER=31
 
 ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
     DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \
@@ -25,7 +24,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,ruby,ruby${RUBY_SHORT_VER}" \
       com.redhat.component="$NAME" \
       name="fedora/$NAME-$RUBY_SHORT_VER" \
-      version="$VERSION" \
+      version=0 \
       usage="s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=${RUBY_VERSION}/test/puma-test-app/ quay.io/fedora/$NAME-$RUBY_SHORT_VER ruby-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 


### PR DESCRIPTION
We no longer use this variable and it seems to be causing some problems for some use-cases.

Resolves: https://github.com/sclorg/s2i-ruby-container/issues/530

@jackorp PTAL.
