### PR TITLE
Fix ruby OpenShift 4 tests suite and and 3.3 imagestreams

### DIFF
--- a/3.3/Dockerfile.fedora
+++ b/3.3/Dockerfile.fedora
@@ -8,7 +8,7 @@ EXPOSE 8080
 ENV NAME=ruby \
     RUBY_VERSION=3.3 \
     RUBY_SHORT_VER=33 \
-    VERSION=0
+    VERSION=
 
 ENV SUMMARY="Platform for building and running Ruby $RUBY_VERSION applications" \
     DESCRIPTION="Ruby $RUBY_VERSION available as container is a base platform for \

--- a/3.3/Dockerfile.fedora
+++ b/3.3/Dockerfile.fedora
@@ -25,7 +25,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,ruby,ruby${RUBY_SHORT_VER}" \
       com.redhat.component="$NAME" \
       name="fedora/$NAME-$RUBY_SHORT_VER" \
-      version="$VERSION" \
+      version="0" \
       usage="s2i build https://github.com/sclorg/s2i-ruby-container.git --context-dir=${RUBY_VERSION}/test/puma-test-app/ quay.io/fedora/$NAME-$RUBY_SHORT_VER ruby-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 

--- a/imagestreams/ruby-centos.json
+++ b/imagestreams/ruby-centos.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Ruby (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.1/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+          "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
           "supports": "ruby",
@@ -22,7 +22,27 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "3.1-ubi8"
+          "name": "3.3-ubi9"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "3.3-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 3.3 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "supports": "ruby:3.3,ruby",
+          "version": "3.3",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi9/ruby-33:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/ruby-rhel-aarch64.json
+++ b/imagestreams/ruby-rhel-aarch64.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Ruby (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.1/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+          "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
           "supports": "ruby",
@@ -22,7 +22,27 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "3.1-ubi8"
+          "name": "3.3-ubi8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "3.3-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 3.3 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "supports": "ruby:3.3,ruby",
+          "version": "3.3",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/ruby-33:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/ruby-rhel-aarch64.json
+++ b/imagestreams/ruby-rhel-aarch64.json
@@ -22,7 +22,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "3.3-ubi8"
+          "name": "3.3-ubi9"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/ruby-rhel.json
+++ b/imagestreams/ruby-rhel.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Ruby (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.1/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
+          "description": "Build and run Ruby applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/3.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major version updates.",
           "iconClass": "icon-ruby",
           "tags": "builder,ruby",
           "supports": "ruby",
@@ -22,7 +22,27 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "3.1-ubi8"
+          "name": "3.3-ubi9"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "3.3-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 3.3 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 3.3 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.3/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "supports": "ruby:3.3,ruby",
+          "version": "3.3",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/ruby-33:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/test-lib-ruby.sh
+++ b/test/test-lib-ruby.sh
@@ -64,7 +64,7 @@ function test_ruby_imagestream() {
 
 function test_ruby_s2i_rails_app() {
   ct_os_test_s2i_app "${IMAGE_NAME}" \
-                    "https://github.com/sclorg/rails-ex#master" \
+                    "https://github.com/sclorg/rails-ex#$(rails_ex_branch)" \
                     . \
                     'Welcome to your Rails application'
 }


### PR DESCRIPTION
This pull request fixes OpenShift 4 tests for version 3.3.
In case ruby 3.3 is tested, then use rails-ex#3.3 branch as well.

In this pull request are updated also 3.3 imagestreams
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
