### PR TITLE
Ruby 30 EOL Mar 2024

### DIFF
--- a/3.0/README.md
+++ b/3.0/README.md
@@ -25,7 +25,7 @@ the nodejs itself is included just to make the npm work.
 
 Usage in Openshift
 ------------------
-For this, we will assume that you are using the `ubi8/ruby-30 image`, available via `ruby:3.0` imagestream tag in Openshift.
+For this, we will assume that you are using the `ubi9/ruby-30 image`, available via `ruby:3.0` imagestream tag in Openshift.
 Building a simple [ruby-sample-app](https://github.com/sclorg/s2i-ruby-container/tree/master/3.0/test/puma-test-app) application
 in Openshift can be achieved with the following step:
 
@@ -64,10 +64,10 @@ To use the Ruby image in a Dockerfile, follow these steps:
 #### 1. Pull a base builder image to build on
 
 ```
-podman pull ubi8/ruby-30
+podman pull ubi9/ruby-30
 ```
 
-An RHEL7 image `ubi8/ruby-30` is used in this example.
+An RHEL7 image `ubi9/ruby-30` is used in this example.
 
 #### 2. Pull and application code
 
@@ -89,7 +89,7 @@ For all these three parts, users can use the Source-to-Image scripts inside the 
 
 ##### 3.1 To use the Source-to-Image scripts and build an image using a Dockerfile, create a Dockerfile with this content:
 ```
-FROM ubi8/ruby-30
+FROM ubi9/ruby-30
 
 # Add application sources to a directory that the assemble scriptexpects them
 # and set permissions so that the container runs without root access
@@ -110,7 +110,7 @@ CMD /usr/libexec/s2i/run
 The s2i scripts are used to set-up and run common Ruby applications. More information about the scripts can be found in [Source-to-Image](#source-to-image-framework-and-scripts) section.
 ##### 3.2 To use your own setup, create a Dockerfile with this content:
 ```
-FROM ubi8/ruby-30
+FROM ubi9/ruby-30
 
 USER 0
 ADD app-src ./

--- a/examples/rails-postgresql-persistent.json
+++ b/examples/rails-postgresql-persistent.json
@@ -530,9 +530,9 @@
     {
       "name": "RUBY_VERSION",
       "displayName": "Ruby Version",
-      "description": "Version of Ruby image to be used (3.0-ubi8 by default).",
+      "description": "Version of Ruby image to be used (3.0-ubi9 by default).",
       "required": true,
-      "value": "3.0-ubi8"
+      "value": "3.0-ubi9"
     },
     {
       "name": "POSTGRESQL_VERSION",

--- a/examples/rails-postgresql.json
+++ b/examples/rails-postgresql.json
@@ -438,9 +438,9 @@
     {
       "name": "RUBY_VERSION",
       "displayName": "Ruby Version",
-      "description": "Version of Ruby image to be used (3.0-ubi8 by default).",
+      "description": "Version of Ruby image to be used (3.0-ubi9 by default).",
       "required": true,
-      "value": "3.0-ubi8"
+      "value": "3.0-ubi9"
     },
     {
       "name": "MEMORY_LIMIT",

--- a/examples/rails.json
+++ b/examples/rails.json
@@ -214,9 +214,9 @@
     {
       "name": "RUBY_VERSION",
       "displayName": "Ruby Version",
-      "description": "Version of Ruby image to be used (3.0-ubi8 by default).",
+      "description": "Version of Ruby image to be used (3.0-ubi9 by default).",
       "required": true,
-      "value": "3.0-ubi8"
+      "value": "3.0-ubi9"
     },
     {
       "name": "MEMORY_LIMIT",

--- a/imagestreams/ruby-centos.json
+++ b/imagestreams/ruby-centos.json
@@ -109,26 +109,6 @@
         }
       },
       {
-        "name": "3.0-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 3.0 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:3.0,ruby",
-          "version": "3.0",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/ruby-30:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "3.0-ubi7",
         "annotations": {
           "openshift.io/display-name": "Ruby 3.0 (UBI 7)",

--- a/imagestreams/ruby-rhel-aarch64.json
+++ b/imagestreams/ruby-rhel-aarch64.json
@@ -109,26 +109,6 @@
         }
       },
       {
-        "name": "3.0-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 3.0 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:3.0,ruby",
-          "version": "3.0",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/ruby-30:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "2.5-ubi8",
         "annotations": {
           "openshift.io/display-name": "Ruby 2.5 (UBI 8)",

--- a/imagestreams/ruby-rhel.json
+++ b/imagestreams/ruby-rhel.json
@@ -109,26 +109,6 @@
         }
       },
       {
-        "name": "3.0-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 3.0 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "supports": "ruby:3.0,ruby",
-          "version": "3.0",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/ruby-30:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "3.0-ubi7",
         "annotations": {
           "openshift.io/display-name": "Ruby 3.0 (UBI 7)",

--- a/test/run
+++ b/test/run
@@ -211,7 +211,12 @@ for server in ${WEB_SERVERS[@]}; do
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "$server"
 done
 
-TEST_LIST="test_from_dockerfile test_from_dockerfile_s2i"
-TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "from_dockerfile"
+if [ "$OS" != "rhel7" ]; then
+  ## SUPPRESS test for rhel7
+  # Step 2/4 : ADD --chown=default:root app-src ./
+  #Unknown flag: chown
+  TEST_LIST="test_from_dockerfile test_from_dockerfile_s2i"
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "from_dockerfile"
+fi
 
 app_cleanup

--- a/test/run
+++ b/test/run
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 #
 # The 'run' performs a simple test that verifies that S2I image.
 # The main focus here is to excersise the S2I scripts.


### PR DESCRIPTION
Ruby-3.0 for RHEL8 reached EOL in Mar 2024

Adds .exclude-rhel8 and removes imagestreams

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
