### PR TITLE
RHEL7 reached EOL in June 2024

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "2.5", "3.0", "3.1", "3.3" ]
-        os_test: [ "fedora", "rhel7", "rhel8", "rhel9"]
+        os_test: [ "fedora", "rhel8", "rhel9"]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "2.5", "3.0", "3.1", "3.3" ]
-        os_test: [ "rhel7", "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9"]
         test_case: [ "openshift-4" ]
 
     steps:

--- a/2.5/README.md
+++ b/2.5/README.md
@@ -225,5 +225,4 @@ See also
 --------
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-ruby-container.
 In that repository you also can find another versions of Ruby environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.
+Dockerfile for RHEL8 it's `Dockerfile.rhel8` and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -225,5 +225,4 @@ See also
 --------
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-ruby-container.
 In that repository you also can find another versions of Ruby environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
+Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/3.1/README.md
+++ b/3.1/README.md
@@ -225,5 +225,4 @@ See also
 --------
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-ruby-container.
 In that repository you also can find another versions of Ruby environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
+Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/3.3/README.md
+++ b/3.3/README.md
@@ -225,5 +225,4 @@ See also
 --------
 Dockerfile and other sources are available on https://github.com/sclorg/s2i-ruby-container.
 In that repository you also can find another versions of Ruby environment Dockerfiles.
-Dockerfile for CentOS is called `Dockerfile`, Dockerfile for RHEL7 is called `Dockerfile.rhel7`,
-for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.
+Dockerfile for RHEL8 it's `Dockerfile.rhel8`, for RHEL9 it's `Dockerfile.rhel9` and the Fedora Dockerfile is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Ruby container images
 [![Build and push images to Quay.io registry](https://github.com/sclorg/s2i-ruby-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/s2i-ruby-container/actions/workflows/build-and-push.yml)
 
 Images available on Quay are:
-* CentOS 7 [ruby-25](https://quay.io/repository/centos7/ruby-25-centos7)
-* CentOS 7 [ruby-30](https://quay.io/repository/centos7/ruby-30-centos7)
 * Fedora [ruby-30](https://quay.io/repository/fedora/ruby-30)
 * Fedora [ruby-31](https://quay.io/repository/fedora/ruby-31)
 
@@ -26,12 +24,10 @@ Ruby versions currently provided are:
 * [Ruby 3.1](3.1/README.md)
 
 RHEL versions currently supported are:
-* RHEL7
 * RHEL8
 * RHEL9
 
 CentOS versions currently supported are:
-* CentOS7
 * CentOS Stream 9
 
 A Ruby 1.9 image can be built from [this third party repository](https://github.com/getupcloud/s2i-ruby/).
@@ -44,11 +40,11 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
 *  **RHEL based image**
 
     These images are available in the
-    [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/ruby-30-rhel7).
+    [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhel8/ruby-30).
     To download it run:
 
     ```
-    $ podman pull registry.access.redhat.com/rhscl/ruby-30-rhel7
+    $ podman pull registry.access.redhat.com/rhel8/ruby-30
     ```
 
     To build a RHEL based Ruby image, you need to run the build on a properly
@@ -57,15 +53,15 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
     ```
     $ git clone --recursive https://github.com/sclorg/s2i-ruby-container.git
     $ cd s2i-ruby-container
-    $ make build TARGET=rhel7 VERSIONS=3.0
+    $ make build TARGET=rhel8 VERSIONS=3.0
     ```
 
-*  **CentOS based image**
+*  **CentOS Stream based image**
 
     This image is available on DockerHub. To download it run:
 
     ```
-    $ podman pull quay.io/centos7/ruby-30-centos7
+    $ podman pull quay.io/sclorg/ruby-30-c9s
     ```
 
     To build a Ruby image from scratch run:
@@ -73,7 +69,7 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
     ```
     $ git clone --recursive https://github.com/sclorg/s2i-ruby-container.git
     $ cd s2i-ruby-container
-    $ make build TARGET=centos7 VERSIONS=3.0
+    $ make build TARGET=c9s VERSIONS=3.0
     ```
 
 Note: while the installation steps are calling `podman`, you can replace any such calls by `docker` with the same arguments.
@@ -104,19 +100,19 @@ Users can choose between testing a Ruby test application based on a RHEL or Cent
 
 *  **RHEL based image**
 
-    To test a RHEL7-based Ruby image, you need to run the test on a properly
+    To test a RHEL8-based Ruby image, you need to run the test on a properly
     subscribed RHEL machine.
 
     ```
     $ cd s2i-ruby-container
-    $ make test TARGET=rhel7 VERSIONS=3.0
+    $ make test TARGET=rhel8 VERSIONS=3.0
     ```
 
-*  **CentOS based image**
+*  **CentOS Stream based image**
 
     ```
     $ cd s2i-ruby-container
-    $ make test TARGET=centos7 VERSIONS=3.0
+    $ make test TARGET=c9s VERSIONS=3.0
     ```
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed
@@ -140,20 +136,20 @@ Image name structure
 
 1. Platform name (lowercase) - ruby
 2. Platform version(without dots) - 30
-3. Base builder image - centos7/rhel7
+3. Base builder image - c9s/rhel8
 
-Examples: `ruby-30-centos7`, `ruby-30-rhel7`
+Examples: `ruby-30-c9s`, `ruby-30`
 
 
 Repository organization
 ------------------------
 * **`<ruby-version>`**
 
-    * **Dockerfile**
+    * **Dockerfile.c9s**
 
-        CentOS based Dockerfile.
+        CentOS Stream based Dockerfile.c9s.
 
-    * **Dockerfile.rhel7**
+    * **Dockerfile.rhel8**
 
         RHEL based Dockerfile. In order to perform build or test actions on this
         Dockerfile you need to run the action on a properly subscribed RHEL machine.

--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -11,9 +11,6 @@
   - filename: ruby-centos.json
     latest: "3.3-ubi9"
     distros:
-      - name: UBI 7
-        app_versions: ["3.0"]
-
       - name: UBI 8
         app_versions: ["2.5", "3.1", "3.3"]
 
@@ -23,9 +20,6 @@
   - filename: ruby-rhel.json
     latest: "3.3-ubi9"
     distros:
-      - name: UBI 7
-        app_versions: ["3.0"]
-
       - name: UBI 8
         app_versions: ["2.5", "3.1", "3.3"]
 

--- a/imagestreams/ruby-centos.json
+++ b/imagestreams/ruby-centos.json
@@ -10,25 +10,6 @@
   "spec": {
     "tags": [
       {
-        "name": "3.0-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 3.0 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 3.0 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "version": "3.0",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi7/ruby-30:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "2.5-ubi8",
         "annotations": {
           "openshift.io/display-name": "Ruby 2.5 (UBI 8)",

--- a/imagestreams/ruby-rhel.json
+++ b/imagestreams/ruby-rhel.json
@@ -10,25 +10,6 @@
   "spec": {
     "tags": [
       {
-        "name": "3.0-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Ruby 3.0 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Ruby 3.0 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
-          "iconClass": "icon-ruby",
-          "tags": "builder,ruby",
-          "version": "3.0",
-          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/ruby-30:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "2.5-ubi8",
         "annotations": {
           "openshift.io/display-name": "Ruby 2.5 (UBI 8)",

--- a/test/run
+++ b/test/run
@@ -22,7 +22,6 @@ TEST_LIST="\
 test_docker_run_usage
 test_application
 test_connection
-test_scl_variables_in_dockerfile
 test_scl_usage
 test_npm_functionality
 "
@@ -140,18 +139,6 @@ function test_application() {
   ct_check_testcase_result $?
 }
 
-function test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-    info "Testing variable presence during \`docker exec\`"
-    ct_check_exec_env_vars
-    ct_check_testcase_result $?
-
-    info "Checking if all scl variables are defined in Dockerfile"
-    ct_check_scl_enable_vars
-    ct_check_testcase_result $?
- fi
-}
-
 function test_from_dockerfile() {
   dockerfile="Dockerfile${1:-}"
   TESTCASE_RESULT=0
@@ -211,12 +198,7 @@ for server in ${WEB_SERVERS[@]}; do
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "$server"
 done
 
-if [ "$OS" != "rhel7" ]; then
-  ## SUPPRESS test for rhel7
-  # Step 2/4 : ADD --chown=default:root app-src ./
-  #Unknown flag: chown
-  TEST_LIST="test_from_dockerfile test_from_dockerfile_s2i"
-  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "from_dockerfile"
-fi
+TEST_LIST="test_from_dockerfile test_from_dockerfile_s2i"
+TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "from_dockerfile"
 
 app_cleanup

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -5,7 +5,7 @@
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 # VERSION specifies the major version of the Ruby runtime in format of X.Y
-# OS specifies RHEL version (e.g. OS=rhel7)
+# OS specifies RHEL version (e.g. OS=rhel8)
 #
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})

--- a/test/test-lib-ruby.sh
+++ b/test/test-lib-ruby.sh
@@ -82,11 +82,7 @@ function test_ruby_s2i_rails_templates() {
 }
 
 function test_ruby_s2i_rails_persistent_templates() {
-  # TODO: this was not working because the referenced example dir was added as part of this commit
-  if [ "${OS}" == "rhel7" ]; then
-    echo "Skip testing Rails Template with Persistent storage on RHEL7."
-    return 0
-  fi
+
   ct_os_test_template_app "${IMAGE_NAME}" \
                         "https://raw.githubusercontent.com/sclorg/rails-ex/master/openshift/templates/rails-postgresql-persistent.json" \
                         "ruby" \
@@ -101,10 +97,6 @@ function test_ruby_s2i_rails_persistent_templates() {
 
 function test_ruby_s2i_local_persistent_templates() {
   # TODO: this was not working because the referenced example dir was added as part of this commit
-  if [ "${OS}" == "rhel7" ]; then
-    echo "Skip testing Rails Template with Persistent storage on RHEL7."
-    return 0
-  fi
   ct_os_test_template_app "${IMAGE_NAME}" \
                         "${THISDIR}/examples/rails-postgresql-persistent.json" \
                         "ruby" \


### PR DESCRIPTION
Removes RHEL7 for building and testing.
