### PR TITLE
Fix tests on fedora

### DIFF
--- a/3.3/test/puma-test-app/Gemfile.lock
+++ b/3.3/test/puma-test-app/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.5.7)
+    nio4r (2.7.3)
     puma (5.2.2)
       nio4r (~> 2.0)
     rack (2.2.3)

--- a/test/run
+++ b/test/run
@@ -54,14 +54,6 @@ run_test_application() {
   docker run --user=100001 --rm --cidfile=${cid_file} ${IMAGE_NAME}-testapp
 }
 
-ct_check_testcase_result() {
-  local result="$1"
-  if [[ "$result" != "0" ]]; then
-    TESTCASE_RESULT=1
-  fi
-  return $result
-}
-
 test_s2i_usage() {
   info "Testing 's2i usage'"
   ct_s2i_usage ${IMAGE_NAME} ${s2i_args} &>/dev/null
@@ -177,6 +169,41 @@ app_cleanup() {
   fi
 }
 
+# Positive test & non-zero exit status = ERROR.
+# Negative test & zero exit status = ERROR.
+# Tests with '-should-fail-' in their name should fail during a build,
+# expecting non-zero exit status.
+evaluate_build_result() {
+  local _result="$1"
+  local _app="$2"
+  local _type="positive"
+  local _test_msg="[PASSED]"
+  local _ret_code=0
+
+  if [[ "$_app" == *"-should-fail-"* ]]; then
+    _type="negative"
+  fi
+
+  if [[ "$_type" == "positive" && "$_result" != "0" ]]; then
+    info "TEST FAILED (${_type}), EXPECTED:0 GOT:${_result}"
+    _ret_code=$_result
+  elif [[ "$_type" == "negative" && "$_result" == "0" ]]; then
+    info "TEST FAILED (${_type}), EXPECTED: non-zero GOT:${_result}"
+    _ret_code=1
+  fi
+  if [ $_ret_code != 0 ]; then
+    cleanup
+    TESTSUITE_RESULT=1
+    _test_msg="[FAILED]"
+  fi
+  ct_update_test_result "$_test_msg" "$_app" run_s2i_build
+
+  if [[ "$_type" == "negative" && "$_result" != "0" ]]; then
+    _ret_code=127 # even though this is success, the app is still not built
+  fi
+  return $_ret_code
+}
+
 pushd ${test_dir}
 if [ -d db-test-app ]; then
   rm -rf db-test-app
@@ -193,7 +220,7 @@ for server in ${WEB_SERVERS[@]}; do
   s2i_args="--pull-policy=never"
 
   run_s2i_build "${server}"
-  ct_check_testcase_result $?
+  evaluate_build_result $? "$server" || continue
 
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "$server"
 done


### PR DESCRIPTION
Two issues are addressed, both mentioned in https://github.com/sclorg/s2i-ruby-container/issues/554. When build fails, it will now handle the situation correctly and stop all depending tests from running while also causing the test to fail and return non-zero code. Code that is handling this is taken from [s2i-python-container](https://github.com/sclorg/s2i-python-container/blob/master/test/run#L273).

While debugging the code, I have encountered a duplicate function defined in the `run` file, despite already being present in `test-lib.sh`, so the local version was removed.

Dependency `nio4r` in `puma-test-app` is bumped to the newest version to prevent build failing. This is related to https://github.com/sclorg/s2i-ruby-container/issues/550.

Fixes: #554