### PR TITLE
Add support for testing C10S

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "2.5", "3.0", "3.1", "3.3" ]
-        os_test: [ "fedora", "rhel8", "rhel9"]
+        os_test: [ "fedora", "rhel8", "rhel9", "c10s" ]
         test_case: [ "container" ]
 
     if: |


### PR DESCRIPTION
Add support for testing C10S

This is first part of C10S support.

The second part will be to update ruby 3.3 so
it is tested.

