### PR TITLE
This commit adds support for building and pushing Ruby 3.3 to quay.io

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -22,6 +22,14 @@ jobs:
             docker_context: "3.3"
             image_name: "ruby-33"
 
+          - dockerfile: "3.3/Dockerfile.c10s"
+            registry_namespace: "sclorg"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+            tag: "c10s"
+            docker_context: "3.3"
+            image_name: "ruby-33-c10s"
+
     steps:
       - name: Build and push to quay.io registry
         uses: sclorg/build-and-push-action@v4

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Ruby container images
 Images available on Quay are:
 * Fedora [ruby-30](https://quay.io/repository/fedora/ruby-30)
 * Fedora [ruby-31](https://quay.io/repository/fedora/ruby-31)
+* Fedora [ruby-33](https://quay.io/repository/fedora/ruby-33)
+* CentOS Stream 10 [ruby-33-c10s](https://quay.io/repository/sclorg/ruby-33-c10s)
 
 This repository contains the source for building various versions of
 the Ruby application as a reproducible container image using
@@ -22,6 +24,7 @@ Ruby versions currently provided are:
 * [Ruby 2.5](2.5/README.md)
 * [Ruby 3.0](3.0/README.md)
 * [Ruby 3.1](3.1/README.md)
+* [Ruby 3.3](3.3/README.md)
 
 RHEL versions currently supported are:
 * RHEL8
@@ -29,6 +32,7 @@ RHEL versions currently supported are:
 
 CentOS versions currently supported are:
 * CentOS Stream 9
+* CentOS Stream 10
 
 A Ruby 1.9 image can be built from [this third party repository](https://github.com/getupcloud/s2i-ruby/).
 It is not maintained by Red Hat nor is part of the OpenShift project.
@@ -40,11 +44,11 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
 *  **RHEL based image**
 
     These images are available in the
-    [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhel8/ruby-30).
+    [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhel9/ruby-30).
     To download it run:
 
     ```
-    $ podman pull registry.access.redhat.com/rhel8/ruby-30
+    $ podman pull registry.access.redhat.com/rhel9/ruby-30
     ```
 
     To build a RHEL based Ruby image, you need to run the build on a properly
@@ -53,7 +57,7 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
     ```
     $ git clone --recursive https://github.com/sclorg/s2i-ruby-container.git
     $ cd s2i-ruby-container
-    $ make build TARGET=rhel8 VERSIONS=3.0
+    $ make build TARGET=rhel9 VERSIONS=3.0
     ```
 
 *  **CentOS Stream based image**
@@ -91,6 +95,9 @@ see [usage documentation](3.0/README.md).
 For information about usage of Dockerfile for Ruby 3.1,
 see [usage documentation](3.1/README.md).
 
+For information about usage of Dockerfile for Ruby 3.3,
+see [usage documentation](3.3/README.md).
+
 Test
 ---------------------
 This repository also provides a [S2I](https://github.com/openshift/source-to-image) test framework,
@@ -100,12 +107,12 @@ Users can choose between testing a Ruby test application based on a RHEL or Cent
 
 *  **RHEL based image**
 
-    To test a RHEL8-based Ruby image, you need to run the test on a properly
+    To test a RHEL9-based Ruby image, you need to run the test on a properly
     subscribed RHEL machine.
 
     ```
     $ cd s2i-ruby-container
-    $ make test TARGET=rhel8 VERSIONS=3.0
+    $ make test TARGET=rhel9 VERSIONS=3.0
     ```
 
 *  **CentOS Stream based image**


### PR DESCRIPTION
This commit adds support for building and pushing Ruby 3.3 to quay.io/sclorg/ruby-33-c10s 
registry.

Allow users testing Ruby-33 on CentOS Stream 10

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->










































































<!-- issue-commentator = {"comment-id":"2377206609"} -->





































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2377169387","data":[{"id":"ded13f3d-db7b-4568-844a-72ad2ad3d3db","name":"Fedora - 3.3","status":"complete","outcome":"passed","runTime":1188.918782,"created":"2024-09-27T10:49:16.509238","updated":"2024-09-27T10:49:16.509245","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ded13f3d-db7b-4568-844a-72ad2ad3d3db\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ded13f3d-db7b-4568-844a-72ad2ad3d3db/pipeline.log\">pipeline</a>"]},{"id":"85154901-fbc2-4d33-a13c-8297a1131c4b","name":"CentOS Stream 10 - 3.3","status":"complete","outcome":"passed","runTime":1247.714831,"created":"2024-09-27T10:49:19.261856","updated":"2024-09-27T10:49:19.261864","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/85154901-fbc2-4d33-a13c-8297a1131c4b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/85154901-fbc2-4d33-a13c-8297a1131c4b/pipeline.log\">pipeline</a>"]},{"id":"2cc0b62f-d044-45d3-b130-fdd7efd93c50","name":"RHEL9 - 3.3","status":"complete","outcome":"passed","runTime":1821.050934,"created":"2024-09-27T10:49:17.160089","updated":"2024-09-27T10:49:17.160096","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2cc0b62f-d044-45d3-b130-fdd7efd93c50\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2cc0b62f-d044-45d3-b130-fdd7efd93c50/pipeline.log\">pipeline</a>"]},{"id":"99444ea3-53c1-4f88-99b3-e59213288074","name":"RHEL8 - 3.3","status":"complete","outcome":"passed","runTime":1896.683801,"created":"2024-09-27T10:49:18.942850","updated":"2024-09-27T10:49:18.942895","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/99444ea3-53c1-4f88-99b3-e59213288074\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/99444ea3-53c1-4f88-99b3-e59213288074/pipeline.log\">pipeline</a>"]},{"id":"43b73f6a-9bce-4284-b2d5-f2c3d5ff9cf9","name":"RHEL9 - 3.0","status":"complete","outcome":"passed","runTime":2027.183487,"created":"2024-09-27T10:49:18.665373","updated":"2024-09-27T10:49:18.665379","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/43b73f6a-9bce-4284-b2d5-f2c3d5ff9cf9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/43b73f6a-9bce-4284-b2d5-f2c3d5ff9cf9/pipeline.log\">pipeline</a>"]},{"id":"fcddb7d8-de54-498b-8798-6cf56f6ebbbc","name":"RHEL8 - 2.5","status":"complete","outcome":"passed","runTime":2049.213057,"created":"2024-09-27T10:49:15.714250","updated":"2024-09-27T10:49:15.714260","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fcddb7d8-de54-498b-8798-6cf56f6ebbbc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fcddb7d8-de54-498b-8798-6cf56f6ebbbc/pipeline.log\">pipeline</a>"]},{"id":"7b24c32a-b413-410c-ae16-1fc10c320bfb","name":"RHEL8 - OpenShift 4 - 3.3","status":"complete","outcome":"passed","runTime":2641.388873,"created":"2024-09-27T10:49:59.054088","updated":"2024-09-27T10:49:59.054096","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b24c32a-b413-410c-ae16-1fc10c320bfb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b24c32a-b413-410c-ae16-1fc10c320bfb/pipeline.log\">pipeline</a>"]},{"id":"108b6c7d-9db7-49f5-99f3-89368380ca18","name":"RHEL8 - 3.1","status":"complete","outcome":"passed","runTime":2029.166076,"created":"2024-09-27T10:49:20.834788","updated":"2024-09-27T10:49:20.834797","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/108b6c7d-9db7-49f5-99f3-89368380ca18\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/108b6c7d-9db7-49f5-99f3-89368380ca18/pipeline.log\">pipeline</a>"]},{"id":"da25e89a-a481-465c-9731-45d202f356b4","name":"RHEL9 - 3.1","status":"complete","outcome":"passed","runTime":2012.155732,"created":"2024-09-27T10:49:17.161650","updated":"2024-09-27T10:49:17.161658","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/da25e89a-a481-465c-9731-45d202f356b4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/da25e89a-a481-465c-9731-45d202f356b4/pipeline.log\">pipeline</a>"]},{"id":"4bc5497f-a2ef-42ef-be02-62b537543103","name":"RHEL9 - PyTest - OpenShift 4 - 3.3","status":"complete","outcome":"passed","runTime":2789.154072,"created":"2024-09-27T10:49:31.746134","updated":"2024-09-27T10:49:31.746144","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bc5497f-a2ef-42ef-be02-62b537543103\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bc5497f-a2ef-42ef-be02-62b537543103/pipeline.log\">pipeline</a>"]},{"id":"da27de04-6b5e-4e7e-ae48-8ab002e26451","name":"RHEL9 - OpenShift 4 - 3.3","status":"complete","outcome":"passed","runTime":2795.85257,"created":"2024-09-27T10:49:49.994890","updated":"2024-09-27T10:49:49.994899","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/da27de04-6b5e-4e7e-ae48-8ab002e26451\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/da27de04-6b5e-4e7e-ae48-8ab002e26451/pipeline.log\">pipeline</a>"]},{"id":"adc1c2d8-6c43-46e9-905d-523a36b251e2","name":"RHEL8 - PyTest - OpenShift 4 - 3.3","status":"complete","outcome":"passed","runTime":2832.110108,"created":"2024-09-27T10:49:33.878106","updated":"2024-09-27T10:49:33.878152","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/adc1c2d8-6c43-46e9-905d-523a36b251e2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/adc1c2d8-6c43-46e9-905d-523a36b251e2/pipeline.log\">pipeline</a>"]},{"id":"1692971c-aaa9-4323-817e-bb8f73a3f235","name":"RHEL9 - OpenShift 4 - 3.1","status":"complete","outcome":"passed","runTime":3688.480412,"created":"2024-09-27T10:49:42.798382","updated":"2024-09-27T10:49:42.798389","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1692971c-aaa9-4323-817e-bb8f73a3f235\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1692971c-aaa9-4323-817e-bb8f73a3f235/pipeline.log\">pipeline</a>"]},{"id":"0d7a31de-34d1-44ea-96e6-eaab3e9f1fb3","name":"RHEL8 - OpenShift 4 - 2.5","status":"complete","outcome":"passed","runTime":3426.68703,"created":"2024-09-27T10:49:35.028054","updated":"2024-09-27T10:49:35.028061","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d7a31de-34d1-44ea-96e6-eaab3e9f1fb3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d7a31de-34d1-44ea-96e6-eaab3e9f1fb3/pipeline.log\">pipeline</a>"]},{"id":"a239c71c-31a2-476c-a21f-f98190f86b7e","name":"RHEL8 - OpenShift 4 - 3.1","status":"complete","outcome":"passed","runTime":3312.800417,"created":"2024-09-27T10:49:33.580242","updated":"2024-09-27T10:49:33.580251","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a239c71c-31a2-476c-a21f-f98190f86b7e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a239c71c-31a2-476c-a21f-f98190f86b7e/pipeline.log\">pipeline</a>"]},{"id":"61f21e0f-bd63-417b-816b-c28adf39be3c","name":"RHEL9 - OpenShift 4 - 3.0","status":"complete","outcome":"passed","runTime":3582.057009,"created":"2024-09-27T10:49:32.245614","updated":"2024-09-27T10:49:32.245622","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/61f21e0f-bd63-417b-816b-c28adf39be3c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/61f21e0f-bd63-417b-816b-c28adf39be3c/pipeline.log\">pipeline</a>"]},{"id":"3a674154-c01e-4cbc-98ba-c42147b6e01a","name":"RHEL8 - PyTest - OpenShift 4 - 2.5","status":"complete","outcome":"passed","runTime":3888.842353,"created":"2024-09-27T10:49:32.392047","updated":"2024-09-27T10:49:32.392055","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a674154-c01e-4cbc-98ba-c42147b6e01a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a674154-c01e-4cbc-98ba-c42147b6e01a/pipeline.log\">pipeline</a>"]},{"id":"b264fb3e-b9d7-49fb-8626-3e19dfad2a3e","name":"RHEL9 - PyTest - OpenShift 4 - 3.0","status":"complete","outcome":"passed","runTime":4194.762811,"created":"2024-09-27T10:49:33.918139","updated":"2024-09-27T10:49:33.918151","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b264fb3e-b9d7-49fb-8626-3e19dfad2a3e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b264fb3e-b9d7-49fb-8626-3e19dfad2a3e/pipeline.log\">pipeline</a>"]},{"id":"fd164fbb-8573-4fc2-a488-32b503a82ea5","name":"RHEL8 - PyTest - OpenShift 4 - 3.1","runTime":3198.761422,"created":"2024-09-27T12:02:07.440328","updated":"2024-09-27T12:02:07.440337","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd164fbb-8573-4fc2-a488-32b503a82ea5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd164fbb-8573-4fc2-a488-32b503a82ea5/pipeline.log\">pipeline</a>"]},{"id":"17f1e708-f0d9-46b4-8a3e-acdd5e0bdccc","name":"RHEL9 - PyTest - OpenShift 4 - 3.1","status":"complete","outcome":"passed","runTime":4302.89904,"created":"2024-09-27T10:49:31.825685","updated":"2024-09-27T10:49:31.825695","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/17f1e708-f0d9-46b4-8a3e-acdd5e0bdccc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/17f1e708-f0d9-46b4-8a3e-acdd5e0bdccc/pipeline.log\">pipeline</a>"]}]} -->