### PR TITLE
Enable testing ruby-container on RHEL10 host

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "2.5", "3.0", "3.1", "3.3" ]
-        os_test: [ "fedora", "rhel8", "rhel9", "c10s" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c10s" ]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-pytests.yml
+++ b/.github/workflows/openshift-pytests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "2.5", "3.0", "3.1", "3.3" ]
-        os_test: [ "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-pytest" ]
 
     steps:

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "2.5", "3.0", "3.1", "3.3" ]
-        os_test: [ "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-4" ]
 
     steps:


### PR DESCRIPTION
Enable testing ruby-container on RHEL10 host.

The code is not changed only GitHub Action.










<!-- issue-commentator = {"comment-id":"2595056801"} -->









































<!-- testing-farm = {"lock":"false","comment-id":"2595039315","data":[{"id":"62b85525-d305-444f-9b8a-50a6b4e3389a","name":"CentOS Stream 10 - 3.3","status":"complete","outcome":"passed","runTime":418.714167,"created":"2025-01-16T09:39:38.935336","updated":"2025-01-16T09:39:38.935345","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/62b85525-d305-444f-9b8a-50a6b4e3389a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/62b85525-d305-444f-9b8a-50a6b4e3389a/pipeline.log\">pipeline</a>"]},{"id":"a88f17ce-5fb0-40e0-896b-4faa42c13a96","name":"Fedora - 3.3","status":"complete","outcome":"passed","runTime":833.820513,"created":"2025-01-16T09:39:53.868264","updated":"2025-01-16T09:39:53.868272","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a88f17ce-5fb0-40e0-896b-4faa42c13a96\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a88f17ce-5fb0-40e0-896b-4faa42c13a96/pipeline.log\">pipeline</a>"]},{"id":"ff3fff2a-d1de-4233-8398-e832c11a9005","name":"RHEL9 - 3.3","status":"complete","outcome":"passed","runTime":3156.619853,"created":"2025-01-16T09:40:31.278463","updated":"2025-01-16T09:40:31.278470","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ff3fff2a-d1de-4233-8398-e832c11a9005\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ff3fff2a-d1de-4233-8398-e832c11a9005/pipeline.log\">pipeline</a>"]},{"id":"994cc2c5-8906-425f-ac48-683bd4fb09a8","name":"RHEL8 - 3.3","status":"complete","outcome":"passed","runTime":3211.260414,"created":"2025-01-16T09:40:34.614475","updated":"2025-01-16T09:40:34.614484","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/994cc2c5-8906-425f-ac48-683bd4fb09a8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/994cc2c5-8906-425f-ac48-683bd4fb09a8/pipeline.log\">pipeline</a>"]},{"id":"f2fd3de1-a114-46d3-99af-5ea8e857174d","name":"RHEL8 - 2.5","status":"complete","outcome":"passed","runTime":3656.408451,"created":"2025-01-16T09:38:14.264554","updated":"2025-01-16T09:38:14.264563","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2fd3de1-a114-46d3-99af-5ea8e857174d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2fd3de1-a114-46d3-99af-5ea8e857174d/pipeline.log\">pipeline</a>"]},{"id":"90840837-727d-4ea7-97fd-b2247ae156c9","name":"RHEL9 - 3.0","status":"complete","outcome":"passed","runTime":3653.885892,"created":"2025-01-16T09:38:39.656965","updated":"2025-01-16T09:38:39.656976","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/90840837-727d-4ea7-97fd-b2247ae156c9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/90840837-727d-4ea7-97fd-b2247ae156c9/pipeline.log\">pipeline</a>"]},{"id":"cc430ef6-7039-4068-b6b9-d75cc431212b","name":"RHEL8 - 3.1","status":"complete","outcome":"passed","runTime":3663.038121,"created":"2025-01-16T09:38:58.484428","updated":"2025-01-16T09:38:58.484439","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc430ef6-7039-4068-b6b9-d75cc431212b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc430ef6-7039-4068-b6b9-d75cc431212b/pipeline.log\">pipeline</a>"]},{"id":"2b7f3693-2e80-4d26-96fa-3ab09d891b4e","name":"RHEL9 - 3.1","runTime":3740.696169,"created":"2025-01-16T09:39:21.151689","updated":"2025-01-16T09:39:21.151696","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b7f3693-2e80-4d26-96fa-3ab09d891b4e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b7f3693-2e80-4d26-96fa-3ab09d891b4e/pipeline.log\">pipeline</a>"]}]} -->