### PR TITLE
Rename ruby-imagestreams and ruby-rails-application for Helm charts

### DIFF
--- a/test/test-lib-ruby.sh
+++ b/test/test-lib-ruby.sh
@@ -55,7 +55,10 @@ function test_ruby_integration() {
 
 # Check the imagestream
 function test_ruby_imagestream() {
-
+  if [[ "${OS}" == "rhel10" ]]; then
+    echo "Testing templates is suppressed on RHEL10. Imagestreams do not exist yet."
+    return
+  fi
   ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/ruby-${OS%[0-9]*}.json" "${IMAGE_NAME}" \
                               "https://github.com/sclorg/s2i-ruby-container.git" \
                               "${VERSION}/test/puma-test-app" \
@@ -82,7 +85,6 @@ function test_ruby_s2i_rails_templates() {
 }
 
 function test_ruby_s2i_rails_persistent_templates() {
-
   ct_os_test_template_app "${IMAGE_NAME}" \
                         "https://raw.githubusercontent.com/sclorg/rails-ex/master/openshift/templates/rails-postgresql-persistent.json" \
                         "ruby" \
@@ -109,6 +111,10 @@ function test_ruby_s2i_local_persistent_templates() {
 }
 
 function test_ruby_s2i_local_app_templates() {
+  if [[ "${OS}" == "rhel10" ]]; then
+    echo "Testing templates is suppressed on RHEL10. Imagestreams do not exist yet."
+    return
+  fi
   # TODO: this was not working because the referenced example dir was added as part of this commit
   ct_os_test_template_app "${IMAGE_NAME}" \
                         "${THISDIR}/examples/rails.json" \

--- a/test/test_helm_ruby_imagestreams.py
+++ b/test/test_helm_ruby_imagestreams.py
@@ -26,7 +26,7 @@ class TestHelmRHELRubyImageStreams:
     def setup_method(self):
         package_name = "redhat-ruby-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_helm_ruby_imagestreams.py
+++ b/test/test_helm_ruby_imagestreams.py
@@ -24,7 +24,7 @@ OS = os.getenv("TARGET")
 class TestHelmRHELRubyImageStreams:
 
     def setup_method(self):
-        package_name = "ruby-imagestreams"
+        package_name = "redhat-ruby-imagestreams"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
         self.hc_api.clone_helm_chart_repo(

--- a/test/test_helm_ruby_rails_application.py
+++ b/test/test_helm_ruby_rails_application.py
@@ -28,12 +28,12 @@ TAGS = {
 TAG = TAGS.get(OS, None)
 
 
-class TestHelmCakePHPTemplate:
+class TestHelmRubyTemplate:
 
     def setup_method(self):
         package_name = "redhat-ruby-rails-application"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_helm_ruby_rails_application.py
+++ b/test/test_helm_ruby_rails_application.py
@@ -23,7 +23,8 @@ OS = os.getenv("TARGET")
 
 TAGS = {
     "rhel8": "-ubi8",
-    "rhel9": "-ubi9"
+    "rhel9": "-ubi9",
+    "rhel10": "-ubi10"
 }
 TAG = TAGS.get(OS, None)
 
@@ -61,12 +62,14 @@ class TestHelmRubyTemplate:
             }
         )
         assert self.hc_api.is_s2i_pod_running(pod_name_prefix="rails-example")
-        assert self.hc_api.test_helm_curl_output(
-            route_name="rails-example",
-            expected_str="Welcome to your Rails application"
+        assert self.hc_api.oc_api.check_response_inside_cluster(
+            name_in_template="rails-example",
+            expected_output="Welcome to your Rails application"
         )
 
     def test_by_helm_test(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10.")
         rails_ex_branch = "master"
         if VERSION == "3.3":
             rails_ex_branch = VERSION
@@ -82,5 +85,5 @@ class TestHelmRubyTemplate:
                 "source_repository_ref": rails_ex_branch,
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="rails-example")
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="rails-example", timeout=480)
         assert self.hc_api.test_helm_chart(expected_str=["Welcome to your Rails application"])

--- a/test/test_helm_ruby_rails_application.py
+++ b/test/test_helm_ruby_rails_application.py
@@ -31,7 +31,7 @@ TAG = TAGS.get(OS, None)
 class TestHelmCakePHPTemplate:
 
     def setup_method(self):
-        package_name = "ruby-rails-application"
+        package_name = "redhat-ruby-rails-application"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
         self.hc_api.clone_helm_chart_repo(
@@ -48,10 +48,10 @@ class TestHelmCakePHPTemplate:
         rails_ex_branch = "master"
         if VERSION == "3.3":
             rails_ex_branch = VERSION
-        self.hc_api.package_name = "ruby-imagestreams"
+        self.hc_api.package_name = "redhat-ruby-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "ruby-rails-application"
+        self.hc_api.package_name = "redhat-ruby-rails-application"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
@@ -70,10 +70,10 @@ class TestHelmCakePHPTemplate:
         rails_ex_branch = "master"
         if VERSION == "3.3":
             rails_ex_branch = VERSION
-        self.hc_api.package_name = "ruby-imagestreams"
+        self.hc_api.package_name = "redhat-ruby-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "ruby-rails-application"
+        self.hc_api.package_name = "redhat-ruby-rails-application"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={

--- a/test/test_ruby_ex_standalone.py
+++ b/test/test_ruby_ex_standalone.py
@@ -20,7 +20,7 @@ OS = os.getenv("TARGET")
 class TestS2IRailsExTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="ruby-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="ruby-testing", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_s2i_imagestreams.py
+++ b/test/test_s2i_imagestreams.py
@@ -20,7 +20,7 @@ SHORT_VERSION = "".join(VERSION.split("."))
 class TestRubyImagestreams:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="ruby", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="ruby", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_s2i_imagestreams.py
+++ b/test/test_s2i_imagestreams.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import pytest
+
 from container_ci_suite.openshift import OpenShiftAPI
 from container_ci_suite.utils import check_variables
 
@@ -12,12 +14,12 @@ if not check_variables():
 
 VERSION = os.getenv("VERSION")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
-OS = os.getenv("OS")
+OS = os.getenv("TARGET")
 
 SHORT_VERSION = "".join(VERSION.split("."))
 
 
-class TestRubyImagestreams:
+class TestRubyS2IImagestreams:
 
     def setup_method(self):
         self.oc_api = OpenShiftAPI(pod_name_prefix="ruby", version=VERSION, shared_cluster=True)
@@ -26,6 +28,8 @@ class TestRubyImagestreams:
         self.oc_api.delete_project()
 
     def ruby(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10.")
         service_name = f"ruby-{SHORT_VERSION}-testing"
         assert self.oc_api.deploy_imagestream_s2i(
             imagestream_file=f"{VERSION}/imagestreams/ruby-rhel.json",

--- a/test/test_s2i_integration.py
+++ b/test/test_s2i_integration.py
@@ -18,7 +18,7 @@ OS = os.getenv("TARGET")
 class TestS2IRubyTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="ruby-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="ruby-testing", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_s2i_local_templates.py
+++ b/test/test_s2i_local_templates.py
@@ -19,7 +19,8 @@ DEPLOYED_PGSQL_IMAGE = "quay.io/sclorg/postgresql-12-c8s"
 
 TAGS = {
     "rhel8": "-el8",
-    "rhel9": "-el9"
+    "rhel9": "-el9",
+    "rhel10": "-el10",
 }
 TAG = TAGS.get(OS, None)
 IMAGE_SHORT = f"postgresql:12{TAG}"
@@ -43,6 +44,8 @@ class TestS2IRailsExTemplate:
         ]
     )
     def test_rails_template_inside_cluster(self, template):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10.")
         service_name = "ruby-testing"
         rails_ex_branch = "master"
         if VERSION == "3.3":


### PR DESCRIPTION
Let's use 'redhat-' prefix as it is required by https://github.com/openshift-helm-charts/charts repo.



<!-- issue-commentator = {"comment-id":"2650758174"} -->



















































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2653650327","data":[{"id":"f140b084-478a-4ce0-a281-4283d027d17d","name":"RHEL10 - OpenShift 4 - 3.3","status":"complete","outcome":"error","runTime":2967.26184,"created":"2025-03-05T13:34:45.711449","updated":"2025-03-05T13:34:45.711455","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f140b084-478a-4ce0-a281-4283d027d17d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f140b084-478a-4ce0-a281-4283d027d17d/pipeline.log\">pipeline</a>"]},{"id":"155225b8-6392-44bb-95e5-2f4d8787661c","name":"RHEL10 - PyTest - OpenShift 4 - 3.3","status":"complete","outcome":"passed","runTime":2139.419674,"created":"2025-03-05T13:35:02.763008","updated":"2025-03-05T13:35:02.763014","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/155225b8-6392-44bb-95e5-2f4d8787661c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/155225b8-6392-44bb-95e5-2f4d8787661c/pipeline.log\">pipeline</a>"]},{"id":"af71737c-4ad2-4a8a-b664-01a22a3ec5b3","name":"RHEL9 - OpenShift 4 - 3.3","status":"complete","outcome":"passed","runTime":2493.416445,"created":"2025-03-05T13:34:44.962644","updated":"2025-03-05T13:34:44.962650","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/af71737c-4ad2-4a8a-b664-01a22a3ec5b3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/af71737c-4ad2-4a8a-b664-01a22a3ec5b3/pipeline.log\">pipeline</a>"]},{"id":"86a1aed9-c368-4c6b-8b4d-f7b08d55eda8","name":"RHEL9 - PyTest - OpenShift 4 - 3.0","runTime":3984.329408,"created":"2025-03-05T14:05:11.639894","updated":"2025-03-05T14:05:11.639902","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/86a1aed9-c368-4c6b-8b4d-f7b08d55eda8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/86a1aed9-c368-4c6b-8b4d-f7b08d55eda8/pipeline.log\">pipeline</a>"]},{"id":"7d42cdf2-4624-47b0-b0c0-8e1775892295","name":"RHEL8 - PyTest - OpenShift 4 - 2.5","status":"complete","outcome":"error","runTime":4796.277173,"created":"2025-03-05T13:34:57.498570","updated":"2025-03-05T13:34:57.498578","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7d42cdf2-4624-47b0-b0c0-8e1775892295\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7d42cdf2-4624-47b0-b0c0-8e1775892295/pipeline.log\">pipeline</a>"]},{"id":"bfa0195e-5897-475e-881d-c680e97120c2","name":"RHEL9 - PyTest - OpenShift 4 - 3.1","status":"complete","outcome":"error","runTime":4299.271388,"created":"2025-03-05T13:44:31.401919","updated":"2025-03-05T13:44:31.401925","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bfa0195e-5897-475e-881d-c680e97120c2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bfa0195e-5897-475e-881d-c680e97120c2/pipeline.log\">pipeline</a>"]},{"id":"48ba858e-00cb-4d8c-9e5c-573896336859","name":"RHEL8 - PyTest - OpenShift 4 - 3.1","status":"complete","outcome":"error","runTime":4847.72178,"created":"2025-03-05T13:34:59.268600","updated":"2025-03-05T13:34:59.268606","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/48ba858e-00cb-4d8c-9e5c-573896336859\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/48ba858e-00cb-4d8c-9e5c-573896336859/pipeline.log\">pipeline</a>"]},{"id":"c573ef75-c529-4476-8da5-9170886cccb0","name":"RHEL9 - PyTest - OpenShift 4 - 3.3","status":"complete","outcome":"error","runTime":4136.309465,"created":"2025-03-05T13:43:32.698986","updated":"2025-03-05T13:43:32.698993","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c573ef75-c529-4476-8da5-9170886cccb0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c573ef75-c529-4476-8da5-9170886cccb0/pipeline.log\">pipeline</a>"]},{"id":"104337b5-0341-43b4-968d-bf736e3f057d","name":"RHEL8 - PyTest - OpenShift 4 - 3.3","status":"complete","outcome":"error","runTime":3844.122092,"created":"2025-03-05T13:35:08.990724","updated":"2025-03-05T13:35:08.990731","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/104337b5-0341-43b4-968d-bf736e3f057d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/104337b5-0341-43b4-968d-bf736e3f057d/pipeline.log\">pipeline</a>"]},{"id":"e45658b0-02f8-4d8a-81d8-9e5d72279366","name":"RHEL9 - OpenShift 4 - 3.0","status":"complete","outcome":"passed","runTime":3544.106801,"created":"2025-03-05T13:34:44.485135","updated":"2025-03-05T13:34:44.485143","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e45658b0-02f8-4d8a-81d8-9e5d72279366\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e45658b0-02f8-4d8a-81d8-9e5d72279366/pipeline.log\">pipeline</a>"]},{"id":"0e36b7b9-b004-40b9-8597-8d9983c69d06","name":"RHEL8 - OpenShift 4 - 2.5","status":"complete","outcome":"passed","runTime":3427.596979,"created":"2025-03-05T13:34:44.049197","updated":"2025-03-05T13:34:44.049203","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e36b7b9-b004-40b9-8597-8d9983c69d06\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e36b7b9-b004-40b9-8597-8d9983c69d06/pipeline.log\">pipeline</a>"]},{"id":"df06c44d-49a6-4bca-a62f-39d9fc094668","name":"RHEL8 - OpenShift 4 - 3.3","status":"complete","outcome":"passed","runTime":2575.740352,"created":"2025-03-05T13:34:43.615948","updated":"2025-03-05T13:34:43.615953","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/df06c44d-49a6-4bca-a62f-39d9fc094668\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/df06c44d-49a6-4bca-a62f-39d9fc094668/pipeline.log\">pipeline</a>"]},{"id":"e0363efb-8e03-43d5-adf3-f12541ea3473","name":"RHEL8 - OpenShift 4 - 3.1","status":"complete","outcome":"passed","runTime":3353.423188,"created":"2025-03-05T13:34:46.715855","updated":"2025-03-05T13:34:46.715861","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e0363efb-8e03-43d5-adf3-f12541ea3473\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e0363efb-8e03-43d5-adf3-f12541ea3473/pipeline.log\">pipeline</a>"]},{"id":"1bf7314b-0871-4401-ade5-077fb70b08d4","name":"RHEL9 - OpenShift 4 - 3.1","status":"complete","outcome":"passed","runTime":3451.934759,"created":"2025-03-05T13:34:45.587558","updated":"2025-03-05T13:34:45.587564","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bf7314b-0871-4401-ade5-077fb70b08d4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bf7314b-0871-4401-ade5-077fb70b08d4/pipeline.log\">pipeline</a>"]},{"id":"2b363258-02e6-4189-b1ba-1dd3496ae55f","name":"CentOS Stream 10 - 3.3","status":"complete","outcome":"passed","runTime":490.336099,"created":"2025-03-05T13:34:27.792451","updated":"2025-03-05T13:34:27.792457","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2b363258-02e6-4189-b1ba-1dd3496ae55f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2b363258-02e6-4189-b1ba-1dd3496ae55f/pipeline.log\">pipeline</a>"]},{"id":"0a1ef6ff-2e6a-4411-933d-db9795ff0192","name":"Fedora - 3.3","status":"complete","outcome":"passed","runTime":545.062013,"created":"2025-03-05T13:34:32.196209","updated":"2025-03-05T13:34:32.196215","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0a1ef6ff-2e6a-4411-933d-db9795ff0192\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0a1ef6ff-2e6a-4411-933d-db9795ff0192/pipeline.log\">pipeline</a>"]},{"id":"1bc51139-1a17-4d07-b3a7-17ec05064a32","name":"RHEL9 - 3.3","status":"complete","outcome":"passed","runTime":1774.19657,"created":"2025-03-05T13:34:30.223263","updated":"2025-03-05T13:34:30.223269","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bc51139-1a17-4d07-b3a7-17ec05064a32\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bc51139-1a17-4d07-b3a7-17ec05064a32/pipeline.log\">pipeline</a>"]},{"id":"f470e6d4-1cb4-43c7-aec2-cf0db5eb2a0c","name":"RHEL10 - 3.3","status":"complete","outcome":"passed","runTime":1823.684522,"created":"2025-03-05T13:34:31.954976","updated":"2025-03-05T13:34:31.954981","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f470e6d4-1cb4-43c7-aec2-cf0db5eb2a0c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f470e6d4-1cb4-43c7-aec2-cf0db5eb2a0c/pipeline.log\">pipeline</a>"]},{"id":"339f6bee-b648-45ca-a4c8-8382166cd549","name":"RHEL8 - 3.3","status":"complete","outcome":"passed","runTime":1956.325155,"created":"2025-03-05T13:34:36.394370","updated":"2025-03-05T13:34:36.394376","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/339f6bee-b648-45ca-a4c8-8382166cd549\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/339f6bee-b648-45ca-a4c8-8382166cd549/pipeline.log\">pipeline</a>"]},{"id":"70dfeb1d-b33d-421c-ac25-e63d82067923","name":"RHEL8 - 2.5","status":"complete","outcome":"passed","runTime":2288.03556,"created":"2025-03-05T13:34:31.101081","updated":"2025-03-05T13:34:31.101087","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/70dfeb1d-b33d-421c-ac25-e63d82067923\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/70dfeb1d-b33d-421c-ac25-e63d82067923/pipeline.log\">pipeline</a>"]},{"id":"8dc8fdc5-1fef-473b-a817-09365c02bce2","name":"RHEL9 - 3.0","status":"complete","outcome":"passed","runTime":2303.597299,"created":"2025-03-05T13:34:28.038961","updated":"2025-03-05T13:34:28.038966","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8dc8fdc5-1fef-473b-a817-09365c02bce2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8dc8fdc5-1fef-473b-a817-09365c02bce2/pipeline.log\">pipeline</a>"]},{"id":"71640c4f-798f-436b-843b-b2f7bfa3b5e1","name":"RHEL9 - 3.1","status":"complete","outcome":"passed","runTime":2322.370657,"created":"2025-03-05T13:34:30.503687","updated":"2025-03-05T13:34:30.503694","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/71640c4f-798f-436b-843b-b2f7bfa3b5e1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/71640c4f-798f-436b-843b-b2f7bfa3b5e1/pipeline.log\">pipeline</a>"]},{"id":"f18997b5-7008-45b5-9b6f-a4e65c0e8959","name":"RHEL8 - 3.1","status":"complete","outcome":"passed","runTime":2355.716121,"created":"2025-03-05T13:34:33.756062","updated":"2025-03-05T13:34:33.756068","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f18997b5-7008-45b5-9b6f-a4e65c0e8959\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f18997b5-7008-45b5-9b6f-a4e65c0e8959/pipeline.log\">pipeline</a>"]}]} -->