### PR TITLE
Run 'from_dockerfile' only on x86_64

### DIFF
--- a/test/run
+++ b/test/run
@@ -235,8 +235,10 @@ for server in ${WEB_SERVERS[@]}; do
   cleanup
 done
 
-TEST_LIST="test_from_dockerfile test_from_dockerfile_s2i"
-TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "from_dockerfile"
+if [[ $(arch) == "x86_64" ]]; then
+  TEST_LIST="test_from_dockerfile test_from_dockerfile_s2i"
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "from_dockerfile"
+fi
 
 
 # Remove all test dependencies


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

On ubi10/ruby-33 and aarch64 these tests failed to compile gem sassc

<!-- issue-commentator = {"comment-id":"2662677800"} -->





















































<!-- testing-farm = {"lock":"false","comment-id":"2665111657","data":[{"id":"578c7f3c-22a8-49b9-88a9-4fccf8df17a5","name":"Fedora - 3.3","status":"complete","outcome":"passed","runTime":619.030415,"created":"2025-02-18T09:37:27.226237","updated":"2025-02-18T09:37:27.226247","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/578c7f3c-22a8-49b9-88a9-4fccf8df17a5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/578c7f3c-22a8-49b9-88a9-4fccf8df17a5/pipeline.log\">pipeline</a>"]},{"id":"455692b1-b706-4b4b-af5f-cd5551736540","name":"CentOS Stream 10 - 3.3","status":"complete","outcome":"passed","runTime":650.328178,"created":"2025-02-18T09:37:25.267730","updated":"2025-02-18T09:37:25.267737","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/455692b1-b706-4b4b-af5f-cd5551736540\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/455692b1-b706-4b4b-af5f-cd5551736540/pipeline.log\">pipeline</a>"]},{"id":"5f5a5dbd-3a0d-4c65-b758-ba2decfd6b19","name":"RHEL9 - 3.3","status":"complete","outcome":"passed","runTime":1069.387272,"created":"2025-02-18T09:37:25.873992","updated":"2025-02-18T09:37:25.873999","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f5a5dbd-3a0d-4c65-b758-ba2decfd6b19\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f5a5dbd-3a0d-4c65-b758-ba2decfd6b19/pipeline.log\">pipeline</a>"]},{"id":"061196b6-1745-414f-ac94-808e384a380e","name":"RHEL10 - 3.3","status":"complete","outcome":"passed","runTime":1056.824112,"created":"2025-02-18T09:37:24.957264","updated":"2025-02-18T09:37:24.957272","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/061196b6-1745-414f-ac94-808e384a380e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/061196b6-1745-414f-ac94-808e384a380e/pipeline.log\">pipeline</a>"]},{"id":"e90960b0-f0eb-4564-9c35-6ef75209684d","name":"RHEL8 - 3.3","status":"complete","outcome":"passed","runTime":1212.431415,"created":"2025-02-18T09:37:27.952451","updated":"2025-02-18T09:37:27.952460","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e90960b0-f0eb-4564-9c35-6ef75209684d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e90960b0-f0eb-4564-9c35-6ef75209684d/pipeline.log\">pipeline</a>"]},{"id":"61330d4e-dfbf-48a6-b37c-11e902f6b72e","name":"RHEL8 - 2.5","status":"complete","outcome":"passed","runTime":1481.009323,"created":"2025-02-18T09:37:25.376588","updated":"2025-02-18T09:37:25.376595","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/61330d4e-dfbf-48a6-b37c-11e902f6b72e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/61330d4e-dfbf-48a6-b37c-11e902f6b72e/pipeline.log\">pipeline</a>"]},{"id":"49f81ee6-702d-45a5-a2d2-028c77fe1f8c","name":"RHEL9 - 3.1","status":"complete","outcome":"passed","runTime":1561.726823,"created":"2025-02-18T09:37:25.709142","updated":"2025-02-18T09:37:25.709152","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/49f81ee6-702d-45a5-a2d2-028c77fe1f8c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/49f81ee6-702d-45a5-a2d2-028c77fe1f8c/pipeline.log\">pipeline</a>"]},{"id":"00270939-2bae-47c6-8843-88cce5764385","name":"RHEL9 - 3.0","status":"complete","outcome":"passed","runTime":1545.274473,"created":"2025-02-18T09:37:26.443728","updated":"2025-02-18T09:37:26.443735","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/00270939-2bae-47c6-8843-88cce5764385\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/00270939-2bae-47c6-8843-88cce5764385/pipeline.log\">pipeline</a>"]},{"id":"2bc1f13b-9fec-4ed7-bae0-b26f824c1811","name":"RHEL8 - 3.1","runTime":1572.58232,"created":"2025-02-18T09:37:23.715359","updated":"2025-02-18T09:37:23.715366","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2bc1f13b-9fec-4ed7-bae0-b26f824c1811\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2bc1f13b-9fec-4ed7-bae0-b26f824c1811/pipeline.log\">pipeline</a>"]}]} -->