### PR TITLE
Disable schedule auto-merge-on-demand

### DIFF
--- a/.github/workflows/auto-merge-on-demand.yml
+++ b/.github/workflows/auto-merge-on-demand.yml
@@ -1,8 +1,8 @@
-name: Auto Merge Scheduled / On Demand
+name: Auto Merge On Demand
 on:
-  schedule:
-    # Workflow runs every 45 minutes
-    - cron: '*/45 * * * *'
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
     inputs:
       pr-number:
@@ -16,7 +16,10 @@ permissions:
 jobs:
   # Get all open PRs
   gather-pull-requests:
-    if: github.repository_owner == 'sclorg'
+    if: |
+      github.repository_owner == 'sclorg'
+      || (contains(github.event.comment.body, '/auto-merge')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
 
     outputs:
@@ -44,7 +47,7 @@ jobs:
         name: Parse manual input
         run: |
           # shellcheck disable=SC2086
-          echo "result="[ ${{ inputs.pr-number }} ]"" >> $GITHUB_OUTPUT
+          echo "result="[ ${{ github.event.issue.number }} ]"" >> $GITHUB_OUTPUT
         shell: bash
 
   validate-pr:


### PR DESCRIPTION
It consumes a lot of GitHub resources like
API rate limits.

Let's use it on request

<!-- issue-commentator = {"comment-id":"2943654423"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2943681095","data":[{"id":"fb5ddf2b-89e2-4565-9153-b9155ac1e3a5","name":"Fedora - 3.3","status":"complete","outcome":"passed","runTime":481.902524,"created":"2025-06-05T10:32:56.591633","updated":"2025-06-05T10:32:56.591640","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fb5ddf2b-89e2-4565-9153-b9155ac1e3a5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fb5ddf2b-89e2-4565-9153-b9155ac1e3a5/pipeline.log\">pipeline</a>"]},{"id":"cc98c84a-dfa6-445e-a1f9-903be0baed9e","name":"CentOS Stream 10 - 3.3","status":"complete","outcome":"passed","runTime":503.86936,"created":"2025-06-05T10:39:10.059688","updated":"2025-06-05T10:39:10.059694","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cc98c84a-dfa6-445e-a1f9-903be0baed9e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cc98c84a-dfa6-445e-a1f9-903be0baed9e/pipeline.log\">pipeline</a>"]},{"id":"d7c18b59-8db7-4303-91fd-139794342067","name":"RHEL10 - 3.3","status":"complete","outcome":"passed","runTime":1008.941528,"created":"2025-06-05T10:32:45.067167","updated":"2025-06-05T10:32:45.067177","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d7c18b59-8db7-4303-91fd-139794342067\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d7c18b59-8db7-4303-91fd-139794342067/pipeline.log\">pipeline</a>"]},{"id":"9101cff9-befa-4522-b3a9-9ede1f5fbfbb","name":"RHEL8 - 3.3","status":"complete","outcome":"passed","runTime":1023.480578,"created":"2025-06-05T10:33:20.563806","updated":"2025-06-05T10:33:20.563812","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9101cff9-befa-4522-b3a9-9ede1f5fbfbb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9101cff9-befa-4522-b3a9-9ede1f5fbfbb/pipeline.log\">pipeline</a>"]},{"id":"f33e0adc-343b-4dff-8692-ea158fe11c8c","name":"RHEL8 - 2.5","status":"complete","outcome":"passed","runTime":1324.612803,"created":"2025-06-05T10:33:01.278654","updated":"2025-06-05T10:33:01.278662","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f33e0adc-343b-4dff-8692-ea158fe11c8c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f33e0adc-343b-4dff-8692-ea158fe11c8c/pipeline.log\">pipeline</a>"]},{"id":"96a0ef07-81dc-4dae-8402-c2fae366bbed","name":"RHEL9 - 3.3","status":"complete","outcome":"passed","runTime":1790.614682,"created":"2025-06-05T10:32:42.988709","updated":"2025-06-05T10:32:42.988716","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/96a0ef07-81dc-4dae-8402-c2fae366bbed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/96a0ef07-81dc-4dae-8402-c2fae366bbed/pipeline.log\">pipeline</a>"]},{"id":"06a54ff2-c229-4846-a82b-f4f24faf7c61","name":"RHEL9 - 3.0","runTime":1483.14505,"created":"2025-06-05T10:38:45.950366","updated":"2025-06-05T10:38:45.950372","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/06a54ff2-c229-4846-a82b-f4f24faf7c61\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/06a54ff2-c229-4846-a82b-f4f24faf7c61/pipeline.log\">pipeline</a>"]}]} -->