### PR TITLE
Test fips for Ruby

### DIFF
--- a/3.0/test/test-fips/Gemfile
+++ b/3.0/test/test-fips/Gemfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'sinatra'
+
+gem 'rackup'
+
+# Use webrick for simple HTTP transport.
+# this is not a production grade server, but gets the job done for the
+# purpose of just sending something over for a request.
+# Additionally there is an option to add SSL later here.
+gem 'webrick'

--- a/3.0/test/test-fips/app.rb
+++ b/3.0/test/test-fips/app.rb
@@ -1,0 +1,72 @@
+require 'sinatra'
+require 'openssl'
+
+set :server, 'webrick'
+set :bind, '0.0.0.0'
+set :port, 8080
+
+MESSAGE = "My secret text\n".freeze
+
+get '/symmetric/aes-256-cbc' do
+  fips_state = OpenSSL.fips_mode ? 'enabled' : 'disabled'
+  # This should pass with and without FIPS.
+  cipher = OpenSSL::Cipher.new('aes-256-cfb')
+  cipher.encrypt
+  cipher.random_key
+  cipher.random_iv
+  enc = cipher.update(MESSAGE) + cipher.final
+  return 200, enc
+rescue => e
+  return 409, "Unexpected failure with aes-256-cbc, fips #{fips_state}, #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+end
+
+get '/symmetric/des-ede-cbc' do
+  status = 200
+  fips_state = OpenSSL.fips_mode ? 'enabled' : 'disabled'
+
+  cipher = OpenSSL::Cipher.new('des-ede-cbc')
+  cipher.encrypt
+  # This fails in FIPS only once we try to get a key for the 3DES.
+  cipher.random_key
+  cipher.random_iv
+  cipher.update(MESSAGE) + cipher.final
+rescue OpenSSL::Cipher::CipherError => e
+  return status, "Failed with fips #{fips_state} #{e.inspect}\n" if OpenSSL.fips_mode
+
+  return 500, "Failed with fips #{fips_state} #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+rescue => e
+  return 409, "Unexpected failure with des-ede-cbc, fips #{fips_state}, #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+end
+
+get '/hash/sha256' do
+  status = 200
+
+  fips_state = OpenSSL.fips_mode ? 'enabled' : 'disabled'
+  message = "SHA256 succeeded, fips is #{fips_state}"
+
+  OpenSSL::Digest.digest('SHA256', MESSAGE)
+
+  return status, message
+rescue => e
+  return 409, "Unexpected failure with SHA256, fips #{fips_state}, #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+end
+
+get '/hash/md5' do
+  status = 200
+
+  fips_state = OpenSSL.fips_mode ? 'enabled' : 'disabled'
+  message = "MD5 succeeded, fips is #{fips_state}"
+
+  OpenSSL::Digest.digest('MD5', MESSAGE)
+
+  # FIPS is on, but this passed, that shouldn't be the case.
+  status = 500 if OpenSSL.fips_mode
+
+  return status, message
+rescue OpenSSL::Digest::DigestError => e
+  return status, "Failed with fips #{fips_state} #{e.inspect}\n" if OpenSSL.fips_mode
+
+  return 500, "Failed with fips #{fips_state} #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+rescue => e
+  return 409, "Unexpected failure with MD5, fips #{fips_state}, #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+end

--- a/3.0/test/test-fips/config.ru
+++ b/3.0/test/test-fips/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/3.3/test/test-fips/Gemfile
+++ b/3.3/test/test-fips/Gemfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'sinatra'
+
+gem 'rackup'
+
+# Use webrick for simple HTTP transport.
+# this is not a production grade server, but gets the job done for the
+# purpose of just sending something over for a request.
+# Additionally there is an option to add SSL later here.
+gem 'webrick'

--- a/3.3/test/test-fips/app.rb
+++ b/3.3/test/test-fips/app.rb
@@ -1,0 +1,72 @@
+require 'sinatra'
+require 'openssl'
+
+set :server, 'webrick'
+set :bind, '0.0.0.0'
+set :port, 8080
+
+MESSAGE = "My secret text\n".freeze
+
+get '/symmetric/aes-256-cbc' do
+  fips_state = OpenSSL.fips_mode ? 'enabled' : 'disabled'
+  # This should pass with and without FIPS.
+  cipher = OpenSSL::Cipher.new('aes-256-cfb')
+  cipher.encrypt
+  cipher.random_key
+  cipher.random_iv
+  enc = cipher.update(MESSAGE) + cipher.final
+  return 200, enc
+rescue => e
+  return 409, "Unexpected failure with aes-256-cbc, fips #{fips_state}, #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+end
+
+get '/symmetric/des-ede-cbc' do
+  status = 200
+  fips_state = OpenSSL.fips_mode ? 'enabled' : 'disabled'
+
+  cipher = OpenSSL::Cipher.new('des-ede-cbc')
+  cipher.encrypt
+  # This fails in FIPS only once we try to get a key for the 3DES.
+  cipher.random_key
+  cipher.random_iv
+  cipher.update(MESSAGE) + cipher.final
+rescue OpenSSL::Cipher::CipherError => e
+  return status, "Failed with fips #{fips_state} #{e.inspect}\n" if OpenSSL.fips_mode
+
+  return 500, "Failed with fips #{fips_state} #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+rescue => e
+  return 409, "Unexpected failure with des-ede-cbc, fips #{fips_state}, #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+end
+
+get '/hash/sha256' do
+  status = 200
+
+  fips_state = OpenSSL.fips_mode ? 'enabled' : 'disabled'
+  message = "SHA256 succeeded, fips is #{fips_state}"
+
+  OpenSSL::Digest.digest('SHA256', MESSAGE)
+
+  return status, message
+rescue => e
+  return 409, "Unexpected failure with SHA256, fips #{fips_state}, #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+end
+
+get '/hash/md5' do
+  status = 200
+
+  fips_state = OpenSSL.fips_mode ? 'enabled' : 'disabled'
+  message = "MD5 succeeded, fips is #{fips_state}"
+
+  OpenSSL::Digest.digest('MD5', MESSAGE)
+
+  # FIPS is on, but this passed, that shouldn't be the case.
+  status = 500 if OpenSSL.fips_mode
+
+  return status, message
+rescue OpenSSL::Digest::DigestError => e
+  return status, "Failed with fips #{fips_state} #{e.inspect}\n" if OpenSSL.fips_mode
+
+  return 500, "Failed with fips #{fips_state} #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+rescue => e
+  return 409, "Unexpected failure with MD5, fips #{fips_state}, #{e.inspect}\nBacktrace:\n#{e.backtrace}\n"
+end

--- a/3.3/test/test-fips/config.ru
+++ b/3.3/test/test-fips/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/test/run
+++ b/test/run
@@ -25,6 +25,12 @@ test_connection
 test_scl_usage
 test_npm_functionality
 "
+
+TEST_LIST_FIPS="\
+test_ruby_fips_mode
+test_ruby_fips_s2i_app
+"
+
 source "${test_dir}/test-lib.sh"
 
 # Read exposed port from image meta data
@@ -51,7 +57,8 @@ run_s2i_build() {
 }
 
 run_test_application() {
-  docker run --user=100001 --rm --cidfile=${cid_file} ${IMAGE_NAME}-testapp
+  local appname=${1:-testapp}
+  docker run --user=100001 --rm --cidfile=${cid_file} ${IMAGE_NAME}-${appname}
 }
 
 test_s2i_usage() {
@@ -169,10 +176,12 @@ app_cleanup() {
 }
 
 function cleanup() {
-  info "Cleaning up the test application image ${IMAGE_NAME}-testapp"
-  if image_exists ${IMAGE_NAME}-testapp; then
-    docker rmi -f ${IMAGE_NAME}-testapp
-  fi
+  for image in testapp testfips; do
+    info "Cleaning up the test application image ${IMAGE_NAME}-${image}"
+    if image_exists ${IMAGE_NAME}-${image}; then
+      docker rmi -f ${IMAGE_NAME}-${image}
+    fi
+  done
 }
 
 # Positive test & non-zero exit status = ERROR.
@@ -208,6 +217,53 @@ evaluate_build_result() {
     _ret_code=127 # even though this is success, the app is still not built
   fi
   return $_ret_code
+}
+
+# "0" if system is not FIPS enabled, "1" if it is.
+function fips_enabled() {
+  local is_fips_enabled
+
+  # Read fips mode from host in case exists
+  if [[ -f /proc/sys/crypto/fips_enabled ]]; then
+    echo "$(cat /proc/sys/crypto/fips_enabled)"
+  else
+    echo "0"
+  fi
+}
+
+function run_s2i_build_fips() {
+  ct_s2i_build_as_df file://${test_dir}/test-fips ${IMAGE_NAME} ${IMAGE_NAME}-testfips ${s2i_args} $1
+}
+
+function test_ruby_fips_mode() {
+  if [[ "$(fips_enabled)" == "0" ]]; then
+    # FIPS disabled -> OpenSSL#fips_mode returns false
+    echo "Fips should be disabled"
+    docker run --rm "$IMAGE_NAME" /bin/bash -c 'ruby -ropenssl -e "exit !OpenSSL.fips_mode"'
+    ct_check_testcase_result "$?"
+  else
+    echo "Fips should be enabled"
+    # FIPS enabled -> OpenSSL#fips_mode returns true
+    docker run --rm "$IMAGE_NAME" /bin/bash -c 'ruby -ropenssl -e "exit OpenSSL.fips_mode"'
+    ct_check_testcase_result "$?"
+  fi
+}
+
+function test_ruby_fips_s2i_app() {
+  run_s2i_build_fips
+  evaluate_build_result $? "default"
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application testfips &
+  # Wait for the container to write its CID file
+  ct_wait_for_cid "${cid_file}"
+  ct_test_response "http://$(container_ip):8080/symmetric/aes-256-cbc" 200 ""
+  ct_check_testcase_result $?
+  ct_test_response "http://$(container_ip):8080/symmetric/des-ede-cbc" 200 ""
+  ct_check_testcase_result $?
+  ct_test_response "http://$(container_ip):8080/hash/sha256" 200 ""
+  ct_check_testcase_result $?
+  ct_test_response "http://$(container_ip):8080/hash/md5" 200 ""
+  ct_check_testcase_result $?
 }
 
 # Prepare dependencies for tests
@@ -247,3 +303,12 @@ echo "Removing test dependencies"
 rm -rf ${test_dir}/db-test-app
 
 app_cleanup
+
+if [[ "$OS" == "rhel8" ]]; then
+  echo "Not executing fips tests on RHEL 8"
+else
+  echo "Testing fips mode"
+  TEST_SET=${TESTS:-$TEST_LIST_FIPS} ct_run_tests_from_testset "fips"
+  echo "Testing the production image build for fips"
+  cleanup
+fi


### PR DESCRIPTION
Worked on mimicking the nodejs approach: https://github.com/sclorg/s2i-nodejs-container/pull/498

The check is simply executing OpenSSL.fips_mode which returns bool.
Based on exit status we can then know whether it failed/succeeded against our expectation.

The app has 4 GET endpoints that executes some OpenSSL capability.
2 of those test symmetric ciphers:
* '/symmetric/aes-256-cbc' -- succeeds under FIPS
* '/symmetric/des-ede-cbc' -- fails under FIPS
2 of those test digests:
* '/hash/sha256' -- succeeds under FIPS
* '/hash/md5' -- fails under FIPS

The app is prepared so that it tests assumptions of when should what
fail, under both FIPS and non-fips environment.

These endpoints either return 200 if the case for them succeeded
or 5xx for FIPS related failures and 4xx for general failures not
accounted for. When a failure happens when it shouldn't, the app also
returns backtrace in the response body.

A few examples:
MD5 succeeds and FIPS is enabled, that's unexpected, returns 500
SHA256 fails in any case, 409 is returned because that shouldn't happen
with both FIPS disabled and enabled, something else went wrong.
MD5 fails with FIPS enabled, that's desired and expected, returns 200.

Since more information is passed within body on response,
`curl --fail-with-body` is recommended.

409 is chosen to differentiate 500 returned in cases we
might expect. It was chosen firstly as it is "user error", either the code is
wrong, or the setup is wrong.

For the purpose of building and running the app,
and adjustment was made to run_test_application to be able to run a custom
named container.

Otherwise there is only testapp to be ran and we can have better names.

<!-- issue-commentator = {"comment-id":"3312389192"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3302576863","data":[{"id":"8ca7f3ef-547f-4b99-a3df-a9e1ab748c88","name":"RHEL8 - 3.3","status":"complete","outcome":"passed","runTime":1016.074618,"created":"2025-10-08T10:11:41.663555","updated":"2025-10-08T10:11:41.663562","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ca7f3ef-547f-4b99-a3df-a9e1ab748c88\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ca7f3ef-547f-4b99-a3df-a9e1ab748c88/pipeline.log\">pipeline</a>"]},{"id":"854da2d3-a94c-477d-b111-dac9908d6828","name":"RHEL8 - 2.5","status":"complete","outcome":"passed","runTime":1300.312594,"created":"2025-10-08T10:11:39.591009","updated":"2025-10-08T10:11:39.591015","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/854da2d3-a94c-477d-b111-dac9908d6828\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/854da2d3-a94c-477d-b111-dac9908d6828/pipeline.log\">pipeline</a>"]},{"id":"e68d0110-f6e0-42d8-8b2e-7a00cd53580d","name":"CentOS Stream 10 - 3.3","status":"complete","outcome":"passed","runTime":622.794131,"created":"2025-10-08T10:11:41.517619","updated":"2025-10-08T10:11:41.517627","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e68d0110-f6e0-42d8-8b2e-7a00cd53580d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e68d0110-f6e0-42d8-8b2e-7a00cd53580d/pipeline.log\">pipeline</a>"]},{"id":"c7e8e775-9c0a-4529-9096-00468b9843bd","name":"Fedora - 3.3","status":"complete","outcome":"passed","runTime":627.7433,"created":"2025-10-08T10:11:40.824674","updated":"2025-10-08T10:11:40.824682","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c7e8e775-9c0a-4529-9096-00468b9843bd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c7e8e775-9c0a-4529-9096-00468b9843bd/pipeline.log\">pipeline</a>"]},{"id":"8264277f-423e-4a0d-b463-4868b6a37a4f","name":"RHEL10 - 3.3","status":"complete","outcome":"passed","runTime":951.287598,"created":"2025-10-08T10:11:38.882388","updated":"2025-10-08T10:11:38.882394","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8264277f-423e-4a0d-b463-4868b6a37a4f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8264277f-423e-4a0d-b463-4868b6a37a4f/pipeline.log\">pipeline</a>"]},{"id":"f8eed22a-3ced-47b5-8959-d1991eee8851","name":"RHEL9 - 3.3","status":"complete","outcome":"passed","runTime":1248.786956,"created":"2025-10-08T10:11:42.049331","updated":"2025-10-08T10:11:42.049337","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8eed22a-3ced-47b5-8959-d1991eee8851\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8eed22a-3ced-47b5-8959-d1991eee8851/pipeline.log\">pipeline</a>"]},{"id":"55de8e8b-e92c-4484-a291-f7ff3288de93","name":"RHEL10 - FIPS Enabled - 3.3","status":"complete","outcome":"passed","runTime":1179.115565,"created":"2025-10-08T10:11:39.104605","updated":"2025-10-08T10:11:39.104611","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/55de8e8b-e92c-4484-a291-f7ff3288de93\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/55de8e8b-e92c-4484-a291-f7ff3288de93/pipeline.log\">pipeline</a>"]},{"id":"33b1c539-1062-4bac-a622-b9f177ebd36d","name":"RHEL9 - 3.0","status":"complete","outcome":"passed","runTime":1788.770502,"created":"2025-10-08T10:11:41.303446","updated":"2025-10-08T10:11:41.303454","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/33b1c539-1062-4bac-a622-b9f177ebd36d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/33b1c539-1062-4bac-a622-b9f177ebd36d/pipeline.log\">pipeline</a>"]},{"id":"8db8c00f-0023-4264-95c0-cde4619693dd","name":"RHEL9 - FIPS Enabled - 3.3","status":"complete","outcome":"passed","runTime":1816.486423,"created":"2025-10-08T10:11:39.244161","updated":"2025-10-08T10:11:39.244170","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8db8c00f-0023-4264-95c0-cde4619693dd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8db8c00f-0023-4264-95c0-cde4619693dd/pipeline.log\">pipeline</a>"]},{"id":"6d84bc8b-8a4f-4092-8dd2-901c825702d5","name":"RHEL9 - FIPS Enabled - 3.0","runTime":2211.633653,"created":"2025-10-08T10:11:39.296070","updated":"2025-10-08T10:11:39.296076","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d84bc8b-8a4f-4092-8dd2-901c825702d5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d84bc8b-8a4f-4092-8dd2-901c825702d5/pipeline.log\">pipeline</a>"]}]} -->