### PR TITLE
Remove 'version' label from Dockerfile.rhel10

### DIFF
--- a/3.3/Dockerfile.rhel10
+++ b/3.3/Dockerfile.rhel10
@@ -28,7 +28,6 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,ruby,ruby${RUBY_SCL_NAME_VERSION},${RUBY_SCL}" \
       com.redhat.component="${RUBY_SCL}-container" \
       name="${IMAGE_NAME}" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       usage="s2i build https://github.com/sclorg/s2i-ruby-container.git \
 --context-dir=${RUBY_VERSION}/test/puma-test-app/ ${IMAGE_NAME} ruby-sample-app" \


### PR DESCRIPTION
Remove 'version' label from Dockerfile.rhel10

Konflux build pipeline needs it.
See https://issues.redhat.com/browse/RHELMISC-17288

<!-- issue-commentator = {"comment-id":"3279394175"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3279620505","data":[{"id":"b24ea6cb-2a56-4477-928f-e910d559929d","name":"Fedora - 3.3","status":"complete","outcome":"passed","runTime":532.470481,"created":"2025-09-11T09:44:11.221232","updated":"2025-09-11T09:44:11.221237","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b24ea6cb-2a56-4477-928f-e910d559929d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b24ea6cb-2a56-4477-928f-e910d559929d/pipeline.log\">pipeline</a>"]},{"id":"722ae6fd-85bf-4309-9f7c-b1b43bbc2d56","name":"RHEL8 - 2.5","status":"complete","outcome":"passed","runTime":1319.042062,"created":"2025-09-11T09:41:52.512205","updated":"2025-09-11T09:41:52.512214","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/722ae6fd-85bf-4309-9f7c-b1b43bbc2d56\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/722ae6fd-85bf-4309-9f7c-b1b43bbc2d56/pipeline.log\">pipeline</a>"]},{"id":"48e764c5-fd5e-4bdc-b8a6-fa99de295939","name":"RHEL10 - 3.3","status":"complete","outcome":"passed","runTime":925.831967,"created":"2025-09-11T09:48:48.917346","updated":"2025-09-11T09:48:48.917355","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/48e764c5-fd5e-4bdc-b8a6-fa99de295939\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/48e764c5-fd5e-4bdc-b8a6-fa99de295939/pipeline.log\">pipeline</a>"]},{"id":"944aff97-4835-425c-ac45-a186fa99d09c","name":"CentOS Stream 10 - 3.3","status":"complete","outcome":"passed","runTime":676.636784,"created":"2025-09-11T09:54:31.160603","updated":"2025-09-11T09:54:31.160611","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/944aff97-4835-425c-ac45-a186fa99d09c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/944aff97-4835-425c-ac45-a186fa99d09c/pipeline.log\">pipeline</a>"]},{"id":"338b8444-aec8-47ff-be2b-9ef04586f1b0","name":"RHEL8 - 3.3","status":"complete","outcome":"passed","runTime":985.258652,"created":"2025-09-11T09:48:31.692451","updated":"2025-09-11T09:48:31.692457","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/338b8444-aec8-47ff-be2b-9ef04586f1b0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/338b8444-aec8-47ff-be2b-9ef04586f1b0/pipeline.log\">pipeline</a>"]},{"id":"74f59f74-c308-4b78-a7b6-cec328efb0f8","name":"RHEL10 - FIPS Enabled - 3.3","status":"complete","outcome":"passed","runTime":1132.721416,"created":"2025-09-11T09:46:51.426948","updated":"2025-09-11T09:46:51.426957","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/74f59f74-c308-4b78-a7b6-cec328efb0f8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/74f59f74-c308-4b78-a7b6-cec328efb0f8/pipeline.log\">pipeline</a>"]},{"id":"70c80fbd-1fcc-4d45-82e3-f2b89df1e49a","name":"RHEL9 - FIPS Enabled - 3.3","status":"complete","outcome":"passed","runTime":1759.42272,"created":"2025-09-11T09:44:58.045738","updated":"2025-09-11T09:44:58.045745","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/70c80fbd-1fcc-4d45-82e3-f2b89df1e49a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/70c80fbd-1fcc-4d45-82e3-f2b89df1e49a/pipeline.log\">pipeline</a>"]},{"id":"27829b84-c90b-45de-bf29-830d0d229b2f","name":"RHEL9 - 3.3","status":"complete","outcome":"passed","runTime":1271.54804,"created":"2025-09-11T09:56:46.431914","updated":"2025-09-11T09:56:46.431923","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/27829b84-c90b-45de-bf29-830d0d229b2f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/27829b84-c90b-45de-bf29-830d0d229b2f/pipeline.log\">pipeline</a>"]},{"id":"257259af-2d1c-465b-8e2d-e8cb9445bb55","name":"RHEL9 - FIPS Enabled - 3.0","status":"complete","outcome":"passed","runTime":2298.929755,"created":"2025-09-11T09:41:50.526817","updated":"2025-09-11T09:41:50.526826","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/257259af-2d1c-465b-8e2d-e8cb9445bb55\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/257259af-2d1c-465b-8e2d-e8cb9445bb55/pipeline.log\">pipeline</a>"]},{"id":"75203fd6-5180-41ea-a512-4eb0b4ef05ed","name":"RHEL9 - 3.0","runTime":1754.686022,"created":"2025-09-11T09:57:46.022777","updated":"2025-09-11T09:57:46.022786","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/75203fd6-5180-41ea-a512-4eb0b4ef05ed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/75203fd6-5180-41ea-a512-4eb0b4ef05ed/pipeline.log\">pipeline</a>"]}]} -->