### PR TITLE
Fix using rails-ex repo and rails-postgresql-persistent.json file

### DIFF
--- a/examples/rails-postgresql-persistent.json
+++ b/examples/rails-postgresql-persistent.json
@@ -176,7 +176,7 @@
             "initContainers": [
               {
                 "name": "ruby-init-container",
-                "image": " ",
+                "image": "${NAME}:latest",
                 "command": [
                   "./migrate-database.sh"
                 ],
@@ -256,7 +256,7 @@
             "containers": [
               {
                 "name": "${NAME}",
-                "image": " ",
+                "image": "${NAME}:latest",
                 "ports": [
                   {
                     "containerPort": 8080
@@ -439,7 +439,7 @@
             "containers": [
               {
                 "name": "postgresql",
-                "image": " ",
+                "image": "postgresql:${POSTGRESQL_VERSION}",
                 "ports": [
                   {
                     "containerPort": 5432

--- a/examples/rails.json
+++ b/examples/rails.json
@@ -18,7 +18,7 @@
   "message": "The following service(s) have been created in your project: ${NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/dancer-ex/blob/master/README.md.",
   "labels": {
       "template": "rails-example",
-      "app": "rails-example"
+      "app": "${NAME}"
   },
   "objects": [
     {

--- a/examples/rails.json
+++ b/examples/rails.json
@@ -155,8 +155,8 @@
           "spec": {
             "containers": [
               {
-                "name": "rails-example",
-                "image": " ",
+                "name": "${NAME}",
+                "image": "${NAME}:latest",
                 "ports": [
                   {
                     "containerPort": 8080

--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -15,10 +15,10 @@
         app_versions: ["2.5", "3.3"]
 
       - name: UBI 9
-        app_versions: ["3.0", "3.3"]
+        app_versions: ["3.0", "3.3", "4.0"]
 
       - name: UBI 10
-        app_versions: ["3.3"]
+        app_versions: ["3.3", "4.0"]
 
   - filename: ruby-rhel.json
     latest: "3.3-ubi9"
@@ -27,10 +27,10 @@
         app_versions: ["2.5", "3.3"]
 
       - name: UBI 9
-        app_versions: ["3.0", "3.3"]
+        app_versions: ["3.0", "3.3", "4.0"]
 
       - name: UBI 10
-        app_versions: ["3.3"]
+        app_versions: ["3.3", "4.0"]
 
   - filename: ruby-rhel-aarch64.json
     latest: "3.3-ubi9"
@@ -39,8 +39,8 @@
         app_versions: ["2.5", "3.3"]
 
       - name: UBI 9
-        app_versions: ["3.0", "3.3"]
+        app_versions: ["3.0", "3.3", "4.0"]
 
       - name: UBI 10
-        app_versions: ["3.3"]
+        app_versions: ["3.3", "4.0"]
 ...

--- a/imagestreams/ruby-centos.json
+++ b/imagestreams/ruby-centos.json
@@ -86,6 +86,25 @@
         }
       },
       {
+        "name": "4.0-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 4.0 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 4.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "version": "4.0",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi9/ruby-40:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "3.3-ubi10",
         "annotations": {
           "openshift.io/display-name": "Ruby 3.3 (UBI 10)",
@@ -99,6 +118,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.access.redhat.com/ubi10/ruby-33:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "4.0-ubi10",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 4.0 (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 4.0 applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "version": "4.0",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi10/ruby-40:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/ruby-rhel-aarch64.json
+++ b/imagestreams/ruby-rhel-aarch64.json
@@ -86,6 +86,25 @@
         }
       },
       {
+        "name": "4.0-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 4.0 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 4.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "version": "4.0",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/ruby-40:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "3.3-ubi10",
         "annotations": {
           "openshift.io/display-name": "Ruby 3.3 (UBI 10)",
@@ -99,6 +118,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi10/ruby-33:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "4.0-ubi10",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 4.0 (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 4.0 applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "version": "4.0",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi10/ruby-40:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/ruby-rhel.json
+++ b/imagestreams/ruby-rhel.json
@@ -86,6 +86,25 @@
         }
       },
       {
+        "name": "4.0-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 4.0 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 4.0 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "version": "4.0",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/ruby-40:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "3.3-ubi10",
         "annotations": {
           "openshift.io/display-name": "Ruby 3.3 (UBI 10)",
@@ -99,6 +118,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi10/ruby-33:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "4.0-ubi10",
+        "annotations": {
+          "openshift.io/display-name": "Ruby 4.0 (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 4.0 applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/4.0/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "version": "4.0",
+          "sampleRepo": "https://github.com/sclorg/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi10/ruby-40:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,3 @@
-import pytest
-
 import os
 
 import sys
@@ -74,6 +72,7 @@ VARS = Vars(
     PSQL_IMAGE_TAG=PSQL_IMAGE_TAG,
     DEPLOYED_PSQL_IMAGE=DEPLOYED_PSQL_IMAGE,
 )
+
 
 def fips_enabled():
     """

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -75,22 +75,6 @@ VARS = Vars(
     DEPLOYED_PSQL_IMAGE=DEPLOYED_PSQL_IMAGE,
 )
 
-
-def skip_ocp_test(reason: str):
-    """
-    Skip an openshift test when the image is not GA yet.
-
-    Args:
-        reason (str): Reason for skipping, either "helm" or "imagestreams"
-    """
-    if VERSION == "4.0":
-        if reason == "imagestreams":
-            pytest.skip(f"Skipping imagestream tests for {VARS.VERSION} on {VARS.OS}. The image is not GA yet.")
-        elif reason == "helm":
-            pytest.skip(f"Skipping Helm tests for {VERSION} on {OS}. The image is not GA yet.")
-        else:
-            print("Invalid reason to skip")
-
 def fips_enabled():
     """
     Check if FIPS is enabled on the system.

--- a/test/test_container_application.py
+++ b/test/test_container_application.py
@@ -1,8 +1,6 @@
-import os
 import pytest
 
 from container_ci_suite.container_lib import ContainerTestLib
-from container_ci_suite.utils import ContainerTestLibUtils
 from container_ci_suite.engines.podman_wrapper import PodmanCLIWrapper
 
 from conftest import VARS

--- a/test/test_container_basics.py
+++ b/test/test_container_basics.py
@@ -1,12 +1,9 @@
-import os
-
 import pytest
 
 from pathlib import Path
 
 from container_ci_suite.container_lib import ContainerTestLib
 from container_ci_suite.engines.podman_wrapper import PodmanCLIWrapper
-from container_ci_suite.utils import ContainerTestLibUtils
 
 from conftest import VARS
 

--- a/test/test_ocp_helm_ruby_imagestreams.py
+++ b/test/test_ocp_helm_ruby_imagestreams.py
@@ -40,6 +40,7 @@ class TestHelmRHELRubyImageStreams:
         """
         Test checks if Helm imagestreams are present
         """
+        skip_ocp_test(reason="helm")
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
         assert (

--- a/test/test_ocp_helm_ruby_imagestreams.py
+++ b/test/test_ocp_helm_ruby_imagestreams.py
@@ -2,12 +2,11 @@ import pytest
 
 from container_ci_suite.helm import HelmChartsAPI
 
-from conftest import VARS, skip_ocp_test
+from conftest import VARS
 
 
 class TestHelmRHELRubyImageStreams:
     def setup_method(self):
-        skip_ocp_test("helm")
         package_name = "redhat-ruby-imagestreams"
 
         self.hc_api = HelmChartsAPI(
@@ -40,7 +39,6 @@ class TestHelmRHELRubyImageStreams:
         """
         Test checks if Helm imagestreams are present
         """
-        skip_ocp_test(reason="helm")
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
         assert (

--- a/test/test_ocp_helm_ruby_imagestreams.py
+++ b/test/test_ocp_helm_ruby_imagestreams.py
@@ -25,23 +25,20 @@ class TestHelmRHELRubyImageStreams:
         self.hc_api.delete_project()
 
     @pytest.mark.parametrize(
-        "version,registry,expected",
+        "version,registry",
         [
-            ("3.3-ubi10", "registry.redhat.io/ubi10/ruby-33:latest", True),
-            ("3.3-ubi9", "registry.redhat.io/ubi9/ruby-33:latest", True),
-            ("3.3-ubi8", "registry.redhat.io/ubi8/ruby-33:latest", True),
-            ("3.0-ubi9", "registry.redhat.io/ubi9/ruby-30:latest", True),
-            ("3.0-ubi8", "registry.redhat.io/ubi8/ruby-30:latest", False),
-            ("2.5-ubi8", "registry.redhat.io/ubi8/ruby-25:latest", True),
+            ("3.3-ubi10", "registry.redhat.io/ubi10/ruby-33:latest"),
+            ("3.3-ubi9", "registry.redhat.io/ubi9/ruby-33:latest"),
+            ("3.3-ubi8", "registry.redhat.io/ubi8/ruby-33:latest"),
+            ("3.0-ubi9", "registry.redhat.io/ubi9/ruby-30:latest"),
+            ("2.5-ubi8", "registry.redhat.io/ubi8/ruby-25:latest"),
+            ("4.0-ubi10", "registry.redhat.io/ubi10/ruby-40:latest"),
         ],
     )
-    def test_package_imagestream(self, version, registry, expected):
+    def test_package_imagestream(self, version, registry):
         """
         Test checks if Helm imagestreams are present
         """
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        assert (
-            self.hc_api.check_imagestreams(version=version, registry=registry)
-            == expected
-        )
+        assert self.hc_api.check_imagestreams(version=version, registry=registry)

--- a/test/test_ocp_helm_ruby_rails_application.py
+++ b/test/test_ocp_helm_ruby_rails_application.py
@@ -38,6 +38,7 @@ class TestHelmRailsRubyTemplate:
         Test if Helm imagestream and Helm ruby rails application
         work properly and respond as expected.
         """
+        skip_ocp_test(reason="helm")
         self.hc_api.package_name = "redhat-ruby-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/test/test_ocp_helm_ruby_rails_application.py
+++ b/test/test_ocp_helm_ruby_rails_application.py
@@ -49,7 +49,7 @@ class TestHelmRailsRubyTemplate:
                 "source_repository_ref": VARS.TEST_APP_BRANCH,
             }
         )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="rails-example")
+        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="rails-example", timeout=480)
         assert self.hc_api.test_helm_chart(
             expected_str=["Welcome to your Rails application"]
         )

--- a/test/test_ocp_helm_ruby_rails_application.py
+++ b/test/test_ocp_helm_ruby_rails_application.py
@@ -1,6 +1,6 @@
 from container_ci_suite.helm import HelmChartsAPI
 
-from conftest import VARS, skip_ocp_test
+from conftest import VARS
 
 
 class TestHelmRailsRubyTemplate:
@@ -13,7 +13,6 @@ class TestHelmRailsRubyTemplate:
         """
         Setup the test environment.
         """
-        skip_ocp_test("helm")
         package_name = "redhat-ruby-rails-application"
         self.hc_api = HelmChartsAPI(
             path=VARS.TEST_DIR,
@@ -38,7 +37,6 @@ class TestHelmRailsRubyTemplate:
         Test if Helm imagestream and Helm ruby rails application
         work properly and respond as expected.
         """
-        skip_ocp_test(reason="helm")
         self.hc_api.package_name = "redhat-ruby-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/test/test_ocp_ruby_ex_standalone.py
+++ b/test/test_ocp_ruby_ex_standalone.py
@@ -33,7 +33,7 @@ class TestS2IRailsExTemplate:
             context=".",
             service_name=service_name,
         )
-        assert self.oc_api.is_template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name,
             expected_output="Welcome to your Rails application",

--- a/test/test_ocp_s2i_imagestreams.py
+++ b/test/test_ocp_s2i_imagestreams.py
@@ -1,6 +1,6 @@
 from container_ci_suite.openshift import OpenShiftAPI
 
-from conftest import VARS, skip_ocp_test
+from conftest import VARS
 
 
 class TestRubyImagestreams:
@@ -12,7 +12,6 @@ class TestRubyImagestreams:
         """
         Setup the test environment.
         """
-        skip_ocp_test("imagestreams")
         self.oc_api = OpenShiftAPI(
             pod_name_prefix=f"ruby-{VARS.SHORT_VERSION}-testing",
             version=VARS.VERSION,

--- a/test/test_ocp_s2i_imagestreams.py
+++ b/test/test_ocp_s2i_imagestreams.py
@@ -36,7 +36,7 @@ class TestRubyImagestreams:
             context=f"{VARS.VERSION}/test/puma-test-app",
             service_name=service_name,
         )
-        assert self.oc_api.is_template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Hello world!"
         )

--- a/test/test_ocp_s2i_integration.py
+++ b/test/test_ocp_s2i_integration.py
@@ -35,7 +35,7 @@ class TestS2IRubyTemplate:
             context=f"{VARS.VERSION}/test/puma-test-app",
             service_name=service_name,
         )
-        assert self.oc_api.is_template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Hello world!"
         )

--- a/test/test_ocp_s2i_integration.py
+++ b/test/test_ocp_s2i_integration.py
@@ -1,5 +1,3 @@
-import pytest
-
 from container_ci_suite.openshift import OpenShiftAPI
 
 from conftest import VARS

--- a/test/test_ocp_s2i_templates.py
+++ b/test/test_ocp_s2i_templates.py
@@ -2,7 +2,7 @@ import pytest
 
 from container_ci_suite.openshift import OpenShiftAPI
 
-from conftest import VARS
+from conftest import VARS, skip_ocp_test
 
 
 class TestS2IRailsTemplates:
@@ -39,6 +39,7 @@ class TestS2IRailsTemplates:
         """
         Test if Ruby s2i local templates work properly
         """
+        skip_ocp_test(reason="imagestream")
         assert self.oc_api.upload_image(VARS.DEPLOYED_PSQL_IMAGE, VARS.PSQL_IMAGE_SHORT)
         service_name = f"ruby-{VARS.SHORT_VERSION}-testing"
         template_url = f"examples/{template_name}"

--- a/test/test_ocp_s2i_templates.py
+++ b/test/test_ocp_s2i_templates.py
@@ -27,27 +27,26 @@ class TestS2IRailsTemplates:
         self.oc_api.delete_project()
 
     @pytest.mark.parametrize(
-        "template_type",
+        "template_type, template_name",
         [
-            "local",
-            "ex",
+            ("local", "rails.json"),
+            ("local", "rails-postgresql-persistent.json"),
+            ("ex", "rails.json"),
+            ("ex", "rails-postgresql-persistent.json"),
         ],
     )
-    def test_rails_template_inside_cluster(self, template_type):
+    def test_rails_template_cluster(self, template_type, template_name):
         """
         Test if Ruby s2i local templates work properly
         """
-        assert self.oc_api.upload_image(
-            VARS.DEPLOYED_PSQL_IMAGE, VARS.PSQL_IMAGE_SHORT
-        )
+        assert self.oc_api.upload_image(VARS.DEPLOYED_PSQL_IMAGE, VARS.PSQL_IMAGE_SHORT)
         service_name = f"ruby-{VARS.SHORT_VERSION}-testing"
-        if template_type == "local":
-            template_url = "examples/rails.json"
-        else:
+        template_url = f"examples/{template_name}"
+        if template_type == "ex":
             template_url = self.oc_api.get_raw_url_for_json(
                 container="rails-ex",
                 dir="openshift/templates",
-                filename="rails.json",
+                filename=template_name,
                 branch=VARS.TEST_APP_BRANCH,
             )
         openshift_args = [
@@ -56,17 +55,14 @@ class TestS2IRailsTemplates:
             f"RUBY_VERSION={VARS.VERSION}",
             f"NAME={service_name}",
         ]
-        # TODO: Add postgresql persistent template
-        # if template != "rails.json":
-        #     openshift_args = [
-        #         "SOURCE_REPOSITORY_URL=https://github.com/sclorg/rails-ex.git",
-        #         f"SOURCE_REPOSITORY_REF={VARS.TEST_APP_BRANCH}",
-        #         f"POSTGRESQL_VERSION={VARS.PSQL_IMAGE_TAG}",
-        #         f"RUBY_VERSION={VARS.VERSION}",
-        #         f"NAME={service_name}",
-        #         "DATABASE_USER=testu",
-        #         "DATABASE_PASSWORD=testp",
-        #     ]
+        if template_name != "rails.json":
+            openshift_args.extend(
+                [
+                    f"POSTGRESQL_VERSION={VARS.PSQL_IMAGE_TAG}",
+                    "DATABASE_USER=testu",
+                    "DATABASE_PASSWORD=testp",
+                ]
+            )
         assert self.oc_api.deploy_template_with_image(
             image_name=VARS.IMAGE_NAME,
             template=template_url,

--- a/test/test_ocp_s2i_templates.py
+++ b/test/test_ocp_s2i_templates.py
@@ -70,7 +70,7 @@ class TestS2IRailsTemplates:
             name_in_template="ruby",
             openshift_args=openshift_args,
         )
-        assert self.oc_api.is_template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=480)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name,
             expected_output="Welcome to your Rails application",

--- a/test/test_ocp_s2i_templates.py
+++ b/test/test_ocp_s2i_templates.py
@@ -16,8 +16,7 @@ class TestS2IRailsTemplates:
         """
         self.oc_api = OpenShiftAPI(
             pod_name_prefix=f"ruby-{VARS.SHORT_VERSION}-testing",
-            version=VARS.VERSION,
-            shared_cluster=True,
+            version=VARS.VERSION
         )
 
     def teardown_method(self):
@@ -30,16 +29,15 @@ class TestS2IRailsTemplates:
         "template_type, template_name",
         [
             ("local", "rails.json"),
-            ("local", "rails-postgresql-persistent.json"),
-            ("ex", "rails.json"),
-            ("ex", "rails-postgresql-persistent.json"),
+            # ("local", "rails-postgresql-persistent.json"),
+            # ("ex", "rails.json"),
+            # ("ex", "rails-postgresql-persistent.json"),
         ],
     )
     def test_rails_template_cluster(self, template_type, template_name):
         """
         Test if Ruby s2i local templates work properly
         """
-        assert self.oc_api.upload_image(VARS.DEPLOYED_PSQL_IMAGE, VARS.PSQL_IMAGE_SHORT)
         service_name = f"ruby-{VARS.SHORT_VERSION}-testing"
         template_url = f"examples/{template_name}"
         if template_type == "ex":
@@ -56,6 +54,7 @@ class TestS2IRailsTemplates:
             f"NAME={service_name}",
         ]
         if template_name != "rails.json":
+            assert self.oc_api.upload_image(VARS.DEPLOYED_PSQL_IMAGE, VARS.PSQL_IMAGE_SHORT)
             openshift_args.extend(
                 [
                     f"POSTGRESQL_VERSION={VARS.PSQL_IMAGE_TAG}",

--- a/test/test_ocp_s2i_templates.py
+++ b/test/test_ocp_s2i_templates.py
@@ -2,7 +2,7 @@ import pytest
 
 from container_ci_suite.openshift import OpenShiftAPI
 
-from conftest import VARS, skip_ocp_test
+from conftest import VARS
 
 
 class TestS2IRailsTemplates:
@@ -39,7 +39,6 @@ class TestS2IRailsTemplates:
         """
         Test if Ruby s2i local templates work properly
         """
-        skip_ocp_test(reason="imagestream")
         assert self.oc_api.upload_image(VARS.DEPLOYED_PSQL_IMAGE, VARS.PSQL_IMAGE_SHORT)
         service_name = f"ruby-{VARS.SHORT_VERSION}-testing"
         template_url = f"examples/{template_name}"
@@ -64,13 +63,16 @@ class TestS2IRailsTemplates:
                     "DATABASE_PASSWORD=testp",
                 ]
             )
+        print(f"Deploying template {template_url} with args {openshift_args}")
         assert self.oc_api.deploy_template_with_image(
             image_name=VARS.IMAGE_NAME,
             template=template_url,
             name_in_template="ruby",
             openshift_args=openshift_args,
         )
-        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=480)
+        assert self.oc_api.is_template_deployed(
+            name_in_template=service_name, timeout=480
+        )
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name,
             expected_output="Welcome to your Rails application",


### PR DESCRIPTION
Fix using rails-ex repo and rails-postgresql-persistent.json file

Missing image definitions

For first test let's use phracek fork

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4325233246"} -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ruby 4.0 ImageStream tags for UBI 9 and UBI 10, including updated version metadata for the supported imagestreams.
  * Improved Rails templates by parameterizing the app identifier and setting explicit container image references (including Postgres by version).

* **Tests**
  * Removed conditional skipping behavior so OpenShift checks run consistently.
  * Updated Rails and imagestream/template deployment readiness tests to use an explicit longer timeout, and adjusted Rails template test parametrization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"true","comment-id":"4325369027","data":[{"id":"5ce4edac-864f-4775-9a5f-0b644efbadcb","name":"RHEL10 - PyTest - OpenShift 4 - 4.0","status":"complete","outcome":"error","runTime":1253.875913,"created":"2026-06-01T10:51:29.899894","updated":"2026-06-01T10:51:29.899899","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ce4edac-864f-4775-9a5f-0b644efbadcb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ce4edac-864f-4775-9a5f-0b644efbadcb/pipeline.log\">pipeline</a>"]},{"id":"75162c96-cd08-4bc2-bd30-f449d15f21bf","name":"RHEL9 - PyTest - OpenShift 4 - 4.0","status":"complete","outcome":"error","runTime":1496.077568,"created":"2026-06-01T11:00:00.916359","updated":"2026-06-01T11:00:00.916366","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/75162c96-cd08-4bc2-bd30-f449d15f21bf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/75162c96-cd08-4bc2-bd30-f449d15f21bf/pipeline.log\">pipeline</a>"]},{"id":"97ba95db-3745-47b0-b890-883f1e2cb644","name":"RHEL8 - PyTest - OpenShift 4 - 3.3","status":"complete","outcome":"error","runTime":1275.457442,"created":"2026-06-01T11:01:07.616161","updated":"2026-06-01T11:01:07.616179","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/97ba95db-3745-47b0-b890-883f1e2cb644\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/97ba95db-3745-47b0-b890-883f1e2cb644/pipeline.log\">pipeline</a>"]},{"id":"36d61601-2e28-4bee-bf8d-880b24c053b2","name":"RHEL9 - PyTest - OpenShift 4 - 3.3","status":"complete","outcome":"error","runTime":1872.394672,"created":"2026-06-01T11:03:05.281813","updated":"2026-06-01T11:03:05.281835","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/36d61601-2e28-4bee-bf8d-880b24c053b2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/36d61601-2e28-4bee-bf8d-880b24c053b2/pipeline.log\">pipeline</a>"]},{"id":"87e8415b-cfef-4054-a27a-18789e970242","name":"RHEL8 - PyTest - OpenShift 4 - 2.5","runTime":3270.176176,"created":"2026-06-01T10:51:05.752620","updated":"2026-06-01T10:51:05.752626","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/87e8415b-cfef-4054-a27a-18789e970242\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/87e8415b-cfef-4054-a27a-18789e970242/pipeline.log\">pipeline</a>"]},{"id":"a272c0f4-32a7-4ce7-aa59-0f9c58650909","name":"RHEL10 - PyTest - OpenShift 4 - 3.3","status":"complete","outcome":"error","runTime":1507.224932,"created":"2026-06-01T11:01:13.180304","updated":"2026-06-01T11:01:13.180311","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a272c0f4-32a7-4ce7-aa59-0f9c58650909\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a272c0f4-32a7-4ce7-aa59-0f9c58650909/pipeline.log\">pipeline</a>"]},{"id":"09e4398c-f9c1-45db-81bd-c6797160c98f","name":"RHEL9 - PyTest - OpenShift 4 - 3.0","status":"complete","outcome":"error","runTime":2018.206338,"created":"2026-06-01T10:47:46.169875","updated":"2026-06-01T10:47:46.169880","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/09e4398c-f9c1-45db-81bd-c6797160c98f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/09e4398c-f9c1-45db-81bd-c6797160c98f/pipeline.log\">pipeline</a>"]}]} -->