### PR TITLE
Add building and testing Ruby 4.0 for Fedora 44

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,6 +30,14 @@ jobs:
             docker_context: "3.3"
             image_name: "ruby-33-c10s"
 
+          - dockerfile: "4.0/Dockerfile.fedora"
+            registry_namespace: "fedora"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            tag: "40"
+            docker_context: "4.0"
+            image_name: "ruby-40"
+
           - dockerfile: "4.0/Dockerfile.c10s"
             registry_namespace: "sclorg"
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Table start
 |2.5||||<details><summary>✓</summary>`registry.redhat.io/rhel8/ruby-25`</details>|||
 |3.0|||||<details><summary>✓</summary>`registry.redhat.io/rhel9/ruby-30`</details>||
 |3.3||<details><summary>✓</summary>`quay.io/sclorg/ruby-33-c10s`</details>|<details><summary>✓</summary>`quay.io/fedora/ruby-33`</details>|<details><summary>✓</summary>`registry.redhat.io/rhel8/ruby-33`</details>|<details><summary>✓</summary>`registry.redhat.io/rhel9/ruby-33`</details>|<details><summary>✓</summary>`registry.redhat.io/rhel10/ruby-33`</details>|
-|4.0||<details><summary>✓</summary>`quay.io/sclorg/ruby-40-c10s`</details>|||<details><summary>✓</summary>`registry.redhat.io/rhel9/ruby-40`</details>|<details><summary>✓</summary>`registry.redhat.io/rhel10/ruby-40`</details>|
+|4.0||<details><summary>✓</summary>`quay.io/sclorg/ruby-40-c10s`</details>|<details><summary>✓</summary>`quay.io/fedora/ruby-40`</details>||<details><summary>✓</summary>`registry.redhat.io/rhel9/ruby-40`</details>|<details><summary>✓</summary>`registry.redhat.io/rhel10/ruby-40`</details>|
 <!--
 Table end
 -->


### PR DESCRIPTION
Fedora 44 is out today, enable building and testing for ruby 4.0 on it
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4335648253"} -->

<!-- testing-farm = {"lock":"true","comment-id":"4336919608","data":[{"id":"c383e04d-a5d8-42df-980e-e5bffac8daae","name":"CentOS Stream 10 - 4.0","status":"complete","outcome":"passed","runTime":904.884144,"created":"2026-04-28T15:37:09.158373","updated":"2026-04-28T15:37:09.158380","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c383e04d-a5d8-42df-980e-e5bffac8daae\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c383e04d-a5d8-42df-980e-e5bffac8daae/pipeline.log\">pipeline</a>"]},{"id":"5eda5276-5148-47bd-b5fb-c03bfeb0fd13","name":"RHEL10 - Unsubscribed host - PyTest - 3.3","status":"complete","outcome":"passed","runTime":1080.191995,"created":"2026-04-28T15:36:59.396063","updated":"2026-04-28T15:36:59.396068","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5eda5276-5148-47bd-b5fb-c03bfeb0fd13\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5eda5276-5148-47bd-b5fb-c03bfeb0fd13/pipeline.log\">pipeline</a>"]},{"id":"d521cf3a-7203-478a-8377-6c37f4a0b5bc","name":"RHEL10 - Unsubscribed host - 3.3","status":"complete","outcome":"passed","runTime":1127.13401,"created":"2026-04-28T15:37:06.265468","updated":"2026-04-28T15:37:06.265474","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d521cf3a-7203-478a-8377-6c37f4a0b5bc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d521cf3a-7203-478a-8377-6c37f4a0b5bc/pipeline.log\">pipeline</a>"]},{"id":"49354083-774f-4a8f-8b24-2dff29cc1241","name":"RHEL10 - PyTest - 4.0","status":"complete","outcome":"passed","runTime":1245.38068,"created":"2026-04-28T15:36:59.745829","updated":"2026-04-28T15:36:59.745834","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/49354083-774f-4a8f-8b24-2dff29cc1241\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/49354083-774f-4a8f-8b24-2dff29cc1241/pipeline.log\">pipeline</a>"]},{"id":"22ad2acc-ddc2-47ea-ad44-6e8cb7fa6178","name":"RHEL8 - 3.3","status":"complete","outcome":"passed","runTime":1263.215239,"created":"2026-04-28T15:37:07.424231","updated":"2026-04-28T15:37:07.424236","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/22ad2acc-ddc2-47ea-ad44-6e8cb7fa6178\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/22ad2acc-ddc2-47ea-ad44-6e8cb7fa6178/pipeline.log\">pipeline</a>"]},{"id":"de410709-b5c6-43ba-8e3b-19d61a059e3b","name":"RHEL8 - 2.5","status":"complete","outcome":"passed","runTime":1205.768667,"created":"2026-04-28T15:37:11.093612","updated":"2026-04-28T15:37:11.093617","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/de410709-b5c6-43ba-8e3b-19d61a059e3b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/de410709-b5c6-43ba-8e3b-19d61a059e3b/pipeline.log\">pipeline</a>"]},{"id":"23f6781d-7795-4c8a-8ade-52c6950e33d0","name":"RHEL9 - 3.3","status":"complete","outcome":"passed","runTime":1264.557838,"created":"2026-04-28T15:37:20.293264","updated":"2026-04-28T15:37:20.293269","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/23f6781d-7795-4c8a-8ade-52c6950e33d0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/23f6781d-7795-4c8a-8ade-52c6950e33d0/pipeline.log\">pipeline</a>"]},{"id":"af1b6c2d-7c8f-4b69-b6d6-6e4022399455","name":"RHEL10 - FIPS Enabled - 4.0","status":"complete","outcome":"passed","runTime":1422.729921,"created":"2026-04-28T15:36:58.665248","updated":"2026-04-28T15:36:58.665255","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/af1b6c2d-7c8f-4b69-b6d6-6e4022399455\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/af1b6c2d-7c8f-4b69-b6d6-6e4022399455/pipeline.log\">pipeline</a>"]},{"id":"02328c4d-8603-4bbc-9ee4-e65b91ca619d","name":"RHEL9 - Unsubscribed host - PyTest - 4.0","status":"complete","outcome":"passed","runTime":1371.038176,"created":"2026-04-28T15:37:05.675134","updated":"2026-04-28T15:37:05.675145","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/02328c4d-8603-4bbc-9ee4-e65b91ca619d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/02328c4d-8603-4bbc-9ee4-e65b91ca619d/pipeline.log\">pipeline</a>"]},{"id":"2eb30938-c26d-4ffa-970b-25919ad1476c","name":"RHEL9 - Unsubscribed host - 4.0","status":"complete","outcome":"passed","runTime":1369.456595,"created":"2026-04-28T15:37:15.691798","updated":"2026-04-28T15:37:15.691803","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2eb30938-c26d-4ffa-970b-25919ad1476c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2eb30938-c26d-4ffa-970b-25919ad1476c/pipeline.log\">pipeline</a>"]},{"id":"bc0ca54c-98cd-4996-9715-45c9640f3148","name":"RHEL9 - 4.0","status":"complete","outcome":"passed","runTime":1529.204691,"created":"2026-04-28T15:36:59.248008","updated":"2026-04-28T15:36:59.248015","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bc0ca54c-98cd-4996-9715-45c9640f3148\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bc0ca54c-98cd-4996-9715-45c9640f3148/pipeline.log\">pipeline</a>"]},{"id":"82c5f6c2-10e0-44ed-893b-5c7f12262e97","name":"Fedora - PyTest - 3.3","status":"complete","outcome":"passed","runTime":409.246808,"created":"2026-04-28T15:55:24.496681","updated":"2026-04-28T15:55:24.496687","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/82c5f6c2-10e0-44ed-893b-5c7f12262e97\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/82c5f6c2-10e0-44ed-893b-5c7f12262e97/pipeline.log\">pipeline</a>"]},{"id":"e5cf2f22-ede2-44b7-bd5d-0e624485c93b","name":"RHEL10 - Unsubscribed host - 4.0","status":"complete","outcome":"passed","runTime":1245.239402,"created":"2026-04-28T15:42:06.285279","updated":"2026-04-28T15:42:06.285284","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e5cf2f22-ede2-44b7-bd5d-0e624485c93b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e5cf2f22-ede2-44b7-bd5d-0e624485c93b/pipeline.log\">pipeline</a>"]},{"id":"ec207bcc-4419-48d4-bdcb-4528f5b0dcec","name":"RHEL9 - PyTest - 3.0","status":"complete","outcome":"passed","runTime":1629.269049,"created":"2026-04-28T15:37:02.721871","updated":"2026-04-28T15:37:02.721876","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec207bcc-4419-48d4-bdcb-4528f5b0dcec\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec207bcc-4419-48d4-bdcb-4528f5b0dcec/pipeline.log\">pipeline</a>"]},{"id":"f8222755-5b34-449f-8a16-2e72c6585bc7","name":"RHEL9 - Unsubscribed host - PyTest - 3.0","status":"complete","outcome":"passed","runTime":1606.264137,"created":"2026-04-28T15:37:15.099831","updated":"2026-04-28T15:37:15.099837","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8222755-5b34-449f-8a16-2e72c6585bc7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f8222755-5b34-449f-8a16-2e72c6585bc7/pipeline.log\">pipeline</a>"]},{"id":"6ec66d07-14b4-434b-aeb5-f4dc43e3fef0","name":"RHEL9 - Unsubscribed host - 3.0","status":"complete","outcome":"passed","runTime":1667.565907,"created":"2026-04-28T15:37:13.065282","updated":"2026-04-28T15:37:13.065287","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ec66d07-14b4-434b-aeb5-f4dc43e3fef0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ec66d07-14b4-434b-aeb5-f4dc43e3fef0/pipeline.log\">pipeline</a>"]},{"id":"fd77d0a3-e543-4583-98dd-465d2def1cdb","name":"RHEL9 - FIPS Enabled - 3.3","status":"complete","outcome":"passed","runTime":1767.356057,"created":"2026-04-28T15:37:01.136635","updated":"2026-04-28T15:37:01.136641","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd77d0a3-e543-4583-98dd-465d2def1cdb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd77d0a3-e543-4583-98dd-465d2def1cdb/pipeline.log\">pipeline</a>"]},{"id":"4b0ade59-1293-4a02-82a8-ccd7618a471f","name":"RHEL9 - FIPS Enabled - 4.0","runTime":1909.094161,"created":"2026-04-28T15:37:00.299769","updated":"2026-04-28T15:37:00.299774","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b0ade59-1293-4a02-82a8-ccd7618a471f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b0ade59-1293-4a02-82a8-ccd7618a471f/pipeline.log\">pipeline</a>"]}]} -->