### PR TITLE
Add RHEL App Streams lifecycle information to READMEs

### DIFF
--- a/2.5/README.md
+++ b/2.5/README.md
@@ -21,6 +21,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for this particular stream.
+
 Usage in Openshift
 ------------------
 For this, we will assume that you are using the `ubi8/ruby-25 image`, available via `ruby:2.5` imagestream tag in Openshift.

--- a/3.0/README.md
+++ b/3.0/README.md
@@ -21,6 +21,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for this particular stream.
+
 Usage in Openshift
 ------------------
 For this, we will assume that you are using the `ubi9/ruby-30 image`, available via `ruby:3.0` imagestream tag in Openshift.

--- a/3.3/README.md
+++ b/3.3/README.md
@@ -23,6 +23,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for this particular stream.
+
 Usage in Openshift
 ------------------
 For this, we will assume that you are using the `ubi10/ruby-33 image`, available via `ruby:3.3` imagestream tag in Openshift.

--- a/4.0/README.md
+++ b/4.0/README.md
@@ -23,6 +23,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for this particular stream.
+
 Usage in Openshift
 ------------------
 For this, we will assume that you are using the `ubi10/ruby-40` image, available via `ruby:4.0` imagestream tag in Openshift.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Table start
 Table end
 -->
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 A Ruby 1.9 image can be built from [this third party repository](https://github.com/getupcloud/s2i-ruby/).
 It is not maintained by Red Hat nor is it part of the OpenShift project.
 


### PR DESCRIPTION
Add a reference to the RHEL App Streams Life Cycle page in all README files to help users understand support timelines for Ruby container streams.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4386896721"} -->